### PR TITLE
Add README.md and LICENSE files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [2024] [Shift Control Pte. Ltd.]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,92 @@
+# SCIM v2
+
+\`scim_v2\` is a Rust crate that provides utilities for working with the System for Cross-domain Identity Management (SCIM) version 2.0 protocol.
+
+## Description
+
+This crate provides functionalities for:
+
+- Models for various SCIM resources such as \`User\`, \`Group\`, \`ResourceType\`, \`ServiceProviderConfig\`, and \`EnterpriseUser\`.
+- Functions for validating these resources.
+- Functions for serializing these resources to JSON.
+- Functions for deserializing these resources from JSON.
+
+## Installation
+
+To use \`scim_v2\` in your project, add the following to your \`Cargo.toml\`:
+
+```toml
+[dependencies]
+scim_v2 = "0.1.0"
+```
+
+Then run \`cargo build\` to download and compile the \`scim_v2\` crate and all its dependencies.
+
+## Usage
+
+Here are some examples of how you can use this crate:
+
+### Validating a User
+
+```rust
+use scim_v2::models::user::User;
+use scim_v2::validate_user;
+
+let user = User {
+    // Initialize user fields here...
+    // ...
+    ..Default::default()
+};
+
+match validate_user(&user) {
+    Ok(_) => println!("User is valid."),
+    Err(e) => println!("User is invalid: {}", e),
+}
+```
+
+### Serializing a User to JSON
+
+```rust
+use scim_v2::models::user::User;
+use scim_v2::user_to_json;
+
+let user = User {
+    // Initialize user fields here...
+    // ...
+    ..Default::default()
+};
+
+match user_to_json(&user) {
+    Ok(json) => println!("User in JSON format: {}", json),
+    Err(e) => println!("Error serializing user to JSON: {}", e),
+}
+```
+
+### Deserializing a User from JSON
+
+```rust
+use scim_v2::models::user::User;
+use scim_v2::json_to_user;
+
+let json = r#"{
+    "userName": "jdoe",
+    "name": {
+        "formatted": "Mr. John Doe"
+    }
+}"#;
+
+match json_to_user(json) {
+    Ok(user) => println!("User: {:?}", user),
+    Err(e) => println!("Error deserializing JSON to User: {}", e),
+}
+```
+
+For more examples and usage details, refer to the documentation of each function and struct.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+[MIT](https://choosealicense.com/licenses/mit/)


### PR DESCRIPTION
This PR includes the addition of a detailed README.md file for the `scim_v2` Rust crate, providing an overview of the project, installation instructions, usage examples, and contribution guidelines. It also adds the MIT License to the project, ensuring the project is open for contributions while protecting the rights of the contributors and users.

The README.md file is structured to provide a comprehensive overview of the project, making it easier for new contributors to understand the project and for users to get started with it.

The MIT License has been added to meet the open-source licensing requirements, allowing others to freely use, change, and distribute the software in the project.

Changes:
- Added README.md
- Added LICENSE