### PR TITLE
Auto release only on tag generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release scim_v2 crate
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*.*.*"
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
When we generate a vx.x.x tag, we'll auto-generate the release.