### PR TITLE
Add scim schema querying and responses

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: hecrj/setup-rust-action@v2
-      with:
-        rust-version: stable
-    - uses: actions/checkout@master
-    - name: Cargo Check
-      run: cargo check
-    - name: Cargo Test
-      run: cargo test
+      - uses: hecrj/setup-rust-action@v2
+        with:
+          rust-version: stable
+      - uses: actions/checkout@master
+      - name: Cargo Check
+        run: cargo check
+      - name: Cargo Test
+        run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ automod = "1.0.14"
 indoc = "2.0.4"
 ref-cast = "1.0.22"
 rustversion = "1.0.14"
-pretty_assertions = "0.7.2"
+pretty_assertions = "1.4.0"
 
 [lib]
 doc-scrape-examples = false

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # SCIM v2
 
-\`scim_v2\` is a Rust crate that provides utilities for working with the System for Cross-domain Identity Management (SCIM) version 2.0 protocol.
+\`scim_v2\` is a Rust crate that provides utilities for working with the System for Cross-domain Identity Management (
+SCIM) version 2.0 protocol.
 
 ## Description
 
 This crate provides functionalities for:
 
-- Models for various SCIM resources such as \`User\`, \`Group\`, \`ResourceType\`, \`ServiceProviderConfig\`, and \`EnterpriseUser\`.
+- Models for various SCIM resources such as \`User\`, \`Group\`, \`ResourceType\`, \`ServiceProviderConfig\`, and \`
+  EnterpriseUser\`.
 - Functions for validating these resources.
 - Functions for serializing these resources to JSON.
 - Functions for deserializing these resources from JSON.
@@ -28,7 +30,7 @@ Here are some examples of how you can use this crate:
 
 ### Validating a User
 
-```rust
+```
 use scim_v2::models::user::User;
 
 let user = User {
@@ -45,25 +47,25 @@ Err(e) => println!("User is invalid: {}", e),
 
 ### Serializing a User to JSON
 
-```rust
+```
 use scim_v2::models::user::User;
 
 let user = User {
 schemas: vec!["urn:ietf:params:scim:schemas:core:2.0:User".to_string()],
 user_name: "jdoe@example.com".to_string(),
 // Initialize other fields as necessary...
-..Default::default()
+..Default::default ()
 };
 
 match user.serialize() {
-Ok(json) => println!("Serialized User: {}", json),
-Err(e) => println!("Serialization error: {}", e),
+Ok(json) => println ! ("Serialized User: {}", json),
+Err(e) => println !("Serialization error: {}", e),
 }
 ```
 
 ### Deserializing a User from JSON
 
-```rust
+```
 use scim_v2::models::user::User;
 
 let user_json = r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"], "userName": "jdoe@example.com"}"#;
@@ -75,16 +77,15 @@ Err(e) => println!("Error converting from JSON to User: {}", e),
 
 You can also use a built-in deserialize function if you’d prefer.
 
-```rust
+```
 use scim_v2::models::user::User;
 
 let user_json = r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"], "userName": "jdoe@example.com"}"#;
 match User::deserialize(user_json) {
-Ok(user) => println!("Deserialized User: {:?}", user),
-Err(e) => println!("Deserialization error: {}", e),
+Ok(user) => println ! ("Deserialized User: {:?}", user),
+Err(e) => println !("Deserialization error: {}", e),
 }
 ```
-
 
 For more examples and usage details, refer to the documentation of each function and struct.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,9 +83,9 @@ extern crate serde;
 extern crate serde_json;
 
 // Include the schema files into the binary.
-const USER_SCHEMA: &'static str = include_str!("schemas/user.json");
-const GROUP_SCHEMA: &'static str = include_str!("schemas/group.json");
-const ENTERPRISE_USER_SCHEMA: &'static str = include_str!("schemas/enterprise_user.json");
+const USER_SCHEMA: &str = include_str!("schemas/user.json");
+const GROUP_SCHEMA: &str = include_str!("schemas/group.json");
+const ENTERPRISE_USER_SCHEMA: &str = include_str!("schemas/enterprise_user.json");
 
 /// Declaring the models module which contains various submodules
 pub mod models {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //! ### Serialize the `User` instance to a JSON string, using the custom SCIMError for error handling.
 //!
 //! # Examples
-//! 
+//!
 //! ```rust
 //! use scim_v2::models::user::User;
 //!
@@ -81,6 +81,11 @@
 /// External crate imports
 extern crate serde;
 extern crate serde_json;
+
+// Include the schema files into the binary.
+const USER_SCHEMA: &'static str = include_str!("schemas/user.json");
+const GROUP_SCHEMA: &'static str = include_str!("schemas/group.json");
+const ENTERPRISE_USER_SCHEMA: &'static str = include_str!("schemas/enterprise_user.json");
 
 /// Declaring the models module which contains various submodules
 pub mod models {

--- a/src/models/group.rs
+++ b/src/models/group.rs
@@ -38,8 +38,6 @@ pub struct Member {
 }
 
 
-
-
 /// Converts a JSON string into a `Group` struct.
 ///
 /// This method attempts to parse a JSON string to construct a `Group` object. It's useful for scenarios where
@@ -227,11 +225,11 @@ mod tests {
 
         // Check meta
         let meta = group.meta.unwrap();
-        assert_eq!(meta.resource_type, "Group");
-        assert_eq!(meta.created, "2010-01-23T04:56:22Z");
-        assert_eq!(meta.last_modified, "2011-05-13T04:42:34Z");
-        assert_eq!(meta.version, "W/\"3694e05e9dff592\"");
-        assert_eq!(meta.location, "https://example.com/v2/Groups/e9e30dba-f08f-4109-8486-d5c6a331660a");
+        assert_eq!(meta.resource_type, Some("Group".to_string()));
+        assert_eq!(meta.created, Some("2010-01-23T04:56:22Z".to_string()));
+        assert_eq!(meta.last_modified, Some("2011-05-13T04:42:34Z".to_string()));
+        assert_eq!(meta.version, Some("W/\"3694e05e9dff592\"".to_string()));
+        assert_eq!(meta.location, Some("https://example.com/v2/Groups/e9e30dba-f08f-4109-8486-d5c6a331660a".to_string()));
     }
 
     #[test]

--- a/src/models/others.rs
+++ b/src/models/others.rs
@@ -5,7 +5,9 @@ use crate::models::user::User;
 #[derive(Serialize, Deserialize)]
 pub struct SearchRequest {
     pub schemas: Vec<String>,
-    pub attributes: Vec<String>,
+    pub attributes: Option<Vec<String>>,
+    #[serde(rename = "excludedAttributes")]
+    excluded_attributes: Option<Vec<String>>,
     pub filter: String,
     #[serde(rename = "startIndex")]
     pub start_index: i64,
@@ -16,7 +18,8 @@ impl Default for SearchRequest {
     fn default() -> Self {
         SearchRequest {
             schemas: vec!["urn:ietf:params:scim:api:messages:2.0:SearchRequest".to_string()],
-            attributes: vec![],
+            attributes: None,
+            excluded_attributes: None,
             filter: "".to_string(),
             start_index: 1,
             count: 100,

--- a/src/models/scim_schema.rs
+++ b/src/models/scim_schema.rs
@@ -1,12 +1,324 @@
 use serde::{Deserialize, Serialize};
 
+use crate::{ENTERPRISE_USER_SCHEMA, GROUP_SCHEMA, USER_SCHEMA};
+use crate::utils::error::SCIMError;
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Meta {
     #[serde(rename = "resourceType")]
-    pub resource_type: String,
-    pub created: String,
+    pub resource_type: Option<String>,
+    pub created: Option<String>,
     #[serde(rename = "lastModified")]
-    pub last_modified: String,
-    pub version: String,
-    pub location: String,
+    pub last_modified: Option<String>,
+    pub version: Option<String>,
+    pub location: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Schema {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub attributes: Vec<Attributes>,
+    pub meta: Meta,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Attributes {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_: String,
+    #[serde(rename = "multiValued")]
+    pub multi_valued: bool,
+    pub description: Option<String>,
+    pub required: Option<bool>,
+    #[serde(rename = "canonicalValues")]
+    pub canonical_values: Option<Vec<String>>,
+    #[serde(rename = "caseExact")]
+    pub case_exact: Option<bool>,
+    pub mutability: Option<String>,
+    pub returned: Option<String>,
+    pub uniqueness: Option<String>,
+    #[serde(rename = "subAttributes")]
+    pub sub_attributes: Option<Vec<SubAttributes>>,
+    #[serde(rename = "referenceTypes")]
+    pub reference_types: Option<Vec<String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SubAttributes {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_: String,
+    #[serde(rename = "multiValued")]
+    pub multi_valued: bool,
+    pub description: Option<String>,
+    pub required: Option<bool>,
+    #[serde(rename = "canonicalValues")]
+    pub canonical_values: Option<Vec<String>>,
+    #[serde(rename = "caseExact")]
+    pub case_exact: Option<bool>,
+    pub mutability: Option<String>,
+    pub returned: Option<String>,
+    pub uniqueness: Option<String>,
+    #[serde(rename = "referenceTypes")]
+    pub reference_types: Option<Vec<String>>,
+}
+
+pub fn get_schemas(schema_names: Vec<&str>) -> Result<Vec<Schema>, SCIMError> {
+    let mut schemas = Vec::new();
+
+    let schema_contents = [
+        ("user", USER_SCHEMA),
+        ("enterprise_user", ENTERPRISE_USER_SCHEMA),
+        ("group", GROUP_SCHEMA),
+    ].iter().cloned().collect::<std::collections::HashMap<_, _>>();
+
+    for schema_name in schema_names {
+        if let Some(schema_content) = schema_contents.get(schema_name) {
+            let schema: Schema = serde_json::from_str(schema_content)?;
+            schemas.push(schema);
+        } else {
+            return Err(SCIMError::SchemaNotFound(schema_name.to_string()));
+        }
+    }
+    Ok(schemas)
+}
+
+/// Converts a JSON string into a `User` struct.
+///
+/// This method attempts to parse a JSON string to construct a `User` object. It's useful for scenarios where
+/// you receive a JSON representation of a user from an external source (e.g., a web request) and you need to
+/// work with this data in a strongly-typed manner within your application.
+///
+/// # Errors
+///
+/// Returns `SCIMError::DeserializationError` if the provided JSON string cannot be parsed into a `User` object.
+///
+/// # Examples
+///
+/// ```rust
+/// use scim_v2::models::user::User;
+///
+/// let user_json = r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"], "userName": "jdoe@example.com"}"#;
+/// match User::try_from(user_json) {
+///     Ok(user) => println!("Successfully converted JSON to User: {:?}", user),
+///     Err(e) => println!("Error converting from JSON to User: {}", e),
+/// }
+/// ```
+impl TryFrom<&str> for Schema {
+    type Error = SCIMError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        serde_json::from_str(value).map_err(SCIMError::DeserializationError)
+    }
+}
+
+impl Schema {
+    /// Serializes the `Schema` instance to a JSON string, using the custom SCIMError for error handling.
+    ///
+    /// # Returns
+    ///
+    /// This method returns a `Result<String, SCIMError>`, where `Ok(String)` contains
+    /// the JSON string representation of the `Schema` instance, and `Err(SCIMError)` contains
+    /// the custom error encountered during serialization.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scim_v2::models::scim_schema::{Schema, Attributes, Meta};
+    ///
+    ///     let user = Schema {
+    ///     id: "urn:ietf:params:scim:schemas:core:2.0:User".to_string(),
+    ///     name: "User".to_string(),
+    ///     description: "User Account".to_string(),
+    ///     attributes: vec![
+    ///         Attributes {
+    ///             name: "userName".to_string(),
+    ///             type_: "string".to_string(),
+    ///             multi_valued: false,
+    ///             description: Some("Unique identifier for the User".to_string()),
+    ///             required: Some(true),
+    ///             canonical_values: None,
+    ///             case_exact: Some(false),
+    ///             mutability: Some("readWrite".to_string()),
+    ///             returned: Some("default".to_string()),
+    ///             uniqueness: Some("server".to_string()),
+    ///             sub_attributes: None,
+    ///             reference_types: None,
+    ///         },
+    ///     ],
+    ///     meta: Meta {
+    ///     resource_type: Some("Schema".to_string()),
+    ///     created: None,
+    ///     last_modified: None,
+    ///     version: None,
+    ///     location: Some("/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User".to_string()),
+    /// },
+    /// };
+    ///
+    /// match user.serialize() {
+    ///     Ok(json) => println!("Serialized User: {}", json),
+    ///     Err(e) => println!("Serialization error: {}", e),
+    /// }
+    /// ```
+    pub fn serialize(&self) -> Result<String, SCIMError> {
+        serde_json::to_string(&self).map_err(SCIMError::SerializationError)
+    }
+
+    /// Deserializes a JSON string into a `Schema` instance, using the custom SCIMError for error handling.
+    ///
+    /// # Parameters
+    ///
+    /// * `json` - A string slice that holds the JSON representation of a `Schema`.
+    ///
+    /// # Returns
+    ///
+    /// This method returns a `Result<Schema, SCIMError>`, where `Ok(User)` is the deserialized `Schema` instance,
+    /// and `Err(SCIMError)` is the custom error encountered during deserialization.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scim_v2::models::scim_schema::Schema;
+    ///
+    /// let schema_json = r#"{
+    ///   "id": "urn:ietf:params:scim:schemas:core:2.0:ResourceType",
+    ///   "name": "ResourceType",
+    ///   "description": "Specifies the schema that describes a SCIM resource type",
+    ///   "attributes": [
+    ///     {
+    ///       "name": "id",
+    ///       "type": "string",
+    ///       "multiValued": false,
+    ///       "description": "The resource type's server unique id. May be the same as the 'name' attribute.",
+    ///       "required": false,
+    ///       "caseExact": false,
+    ///       "mutability": "readOnly",
+    ///       "returned": "default",
+    ///       "uniqueness": "none"
+    ///     },
+    ///     {
+    ///       "name": "name",
+    ///       "type": "string",
+    ///       "multiValued": false,
+    ///       "description": "The resource type name.  When applicable, service providers MUST specify the name, e.g., 'User'.",
+    ///       "required": true,
+    ///       "caseExact": false,
+    ///       "mutability": "readOnly",
+    ///       "returned": "default",
+    ///       "uniqueness": "none"
+    ///     },
+    ///     {
+    ///       "name": "description",
+    ///       "type": "string",
+    ///       "multiValued": false,
+    ///       "description": "The resource type's human-readable description.  When applicable, service providers MUST specify the description.",
+    ///       "required": false,
+    ///       "caseExact": false,
+    ///       "mutability": "readOnly",
+    ///       "returned": "default",
+    ///       "uniqueness": "none"
+    ///     },
+    ///     {
+    ///       "name": "endpoint",
+    ///       "type": "reference",
+    ///       "referenceTypes": [
+    ///         "uri"
+    ///       ],
+    ///       "multiValued": false,
+    ///       "description": "The resource type's HTTP-addressable endpoint relative to the Base URL, e.g., '/Users'.",
+    ///       "required": true,
+    ///       "caseExact": false,
+    ///       "mutability": "readOnly",
+    ///       "returned": "default",
+    ///       "uniqueness": "none"
+    ///     },
+    ///     {
+    ///       "name": "schema",
+    ///       "type": "reference",
+    ///       "referenceTypes": [
+    ///         "uri"
+    ///       ],
+    ///       "multiValued": false,
+    ///       "description": "The resource type's primary/base schema URI.",
+    ///       "required": true,
+    ///       "caseExact": true,
+    ///       "mutability": "readOnly",
+    ///       "returned": "default",
+    ///       "uniqueness": "none"
+    ///     },
+    ///     {
+    ///       "name": "schemaExtensions",
+    ///       "type": "complex",
+    ///       "multiValued": false,
+    ///       "description": "A list of URIs of the resource type's schema extensions.",
+    ///       "required": true,
+    ///       "mutability": "readOnly",
+    ///       "returned": "default",
+    ///       "subAttributes": [
+    ///         {
+    ///           "name": "schema",
+    ///           "type": "reference",
+    ///           "referenceTypes": [
+    ///             "uri"
+    ///           ],
+    ///           "multiValued": false,
+    ///           "description": "The URI of a schema extension.",
+    ///           "required": true,
+    ///           "caseExact": true,
+    ///           "mutability": "readOnly",
+    ///           "returned": "default",
+    ///           "uniqueness": "none"
+    ///         },
+    ///         {
+    ///           "name": "required",
+    ///           "type": "boolean",
+    ///           "multiValued": false,
+    ///           "description": "A Boolean value that specifies whether or not the schema extension is required for the resource type.  If true, a resource of this type MUST include this schema extension and also include any attributes declared as required in this schema extension. If false, a resource of this type MAY omit this schema extension.",
+    ///           "required": true,
+    ///           "mutability": "readOnly",
+    ///           "returned": "default"
+    ///         }
+    ///       ]
+    ///     }
+    ///   ]
+    /// }"#;
+    /// match Schema::deserialize(schema_json) {
+    ///     Ok(schema) => println!("Deserialized User: {:?}", schema),
+    ///     Err(e) => println!("Deserialization error: {}", e),
+    /// }
+    /// ```
+    pub fn deserialize(json: &str) -> Result<Self, SCIMError> {
+        serde_json::from_str(json).map_err(SCIMError::DeserializationError)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_schemas_returns_correct_schemas_for_valid_input() {
+        let schemas = get_schemas(vec!["user"]).unwrap();
+        assert_eq!(schemas.len(), 1);
+        assert_eq!(schemas[0].id, "urn:ietf:params:scim:schemas:core:2.0:User");
+        assert_eq!(schemas[0].name, "User");
+        assert_eq!(schemas[0].description, "User Account");
+        assert_eq!(schemas[0].attributes.len(), 21);
+        assert_eq!(schemas[0].meta.resource_type.as_ref(), Some(&"Schema".to_string()));
+        assert_eq!(schemas[0].meta.location.as_ref(), Some(&"/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User".to_string()));
+    }
+
+    #[test]
+    fn get_schemas_returns_error_for_invalid_input() {
+        let result = get_schemas(vec!["invalid"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_schemas_returns_error_for_missing_file() {
+        let result = get_schemas(vec!["missing"]);
+        assert!(result.is_err());
+    }
 }

--- a/src/models/service_provider_config.rs
+++ b/src/models/service_provider_config.rs
@@ -102,8 +102,6 @@ pub struct Supported {
 }
 
 
-
-
 /// Converts a JSON string into a `ServiceProviderConfig` struct.
 ///
 /// This method attempts to parse a JSON string to construct a `ServiceProviderConfig` object. It's useful for scenarios where

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -94,7 +94,6 @@ pub struct Name {
 }
 
 
-
 #[derive(Serialize, Deserialize, Debug)]
 #[derive(Default)]
 pub struct Email {
@@ -104,7 +103,6 @@ pub struct Email {
     pub type_: Option<String>,
     pub primary: Option<bool>,
 }
-
 
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -123,7 +121,6 @@ pub struct Address {
 }
 
 
-
 #[derive(Serialize, Deserialize, Debug)]
 #[derive(Default)]
 pub struct PhoneNumber {
@@ -133,7 +130,6 @@ pub struct PhoneNumber {
     pub type_: Option<String>,
     pub primary: Option<bool>,
 }
-
 
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -147,7 +143,6 @@ pub struct Im {
 }
 
 
-
 #[derive(Serialize, Deserialize, Debug)]
 #[derive(Default)]
 pub struct Photo {
@@ -157,7 +152,6 @@ pub struct Photo {
     pub type_: Option<String>,
     pub primary: Option<bool>,
 }
-
 
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -171,7 +165,6 @@ pub struct Group {
 }
 
 
-
 #[derive(Serialize, Deserialize, Debug)]
 #[derive(Default)]
 pub struct Entitlement {
@@ -181,7 +174,6 @@ pub struct Entitlement {
     pub type_: Option<String>,
     pub primary: Option<bool>,
 }
-
 
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -195,7 +187,6 @@ pub struct Role {
 }
 
 
-
 #[derive(Serialize, Deserialize, Debug)]
 #[derive(Default)]
 pub struct X509Certificate {
@@ -205,8 +196,6 @@ pub struct X509Certificate {
     pub type_: Option<String>,
     pub primary: Option<bool>,
 }
-
-
 
 
 /// Converts a JSON string into a `User` struct.
@@ -375,11 +364,11 @@ mod tests {
         assert_eq!(user.id, Some("2819c223-7f76-453a-919d-413861904646".to_string()));
         assert_eq!(user.user_name, "bjensen@example.com");
         let meta = user.meta.unwrap();
-        assert_eq!(meta.resource_type, "User");
-        assert_eq!(meta.created, "2010-01-23T04:56:22Z");
-        assert_eq!(meta.last_modified, "2011-05-13T04:42:34Z");
-        assert_eq!(meta.version, "W/\"3694e05e9dff590\"");
-        assert_eq!(meta.location, "https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646");
+        assert_eq!(meta.resource_type, Some("User".to_string()));
+        assert_eq!(meta.created, Some("2010-01-23T04:56:22Z".to_string()));
+        assert_eq!(meta.last_modified, Some("2011-05-13T04:42:34Z".to_string()));
+        assert_eq!(meta.version, Some("W/\"3694e05e9dff590\"".to_string()));
+        assert_eq!(meta.location, Some("https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646".to_string()));
     }
 
     #[test]
@@ -527,11 +516,11 @@ mod tests {
         assert_eq!(user.x509_certificates.as_ref().unwrap().len(), 1);
         assert_eq!(user.x509_certificates.as_ref().unwrap()[0].value, Some("MIIDQzCCAqygAwIBAgICEAAwDQYJKoZIhvcNAQEFBQAwTjELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFDASBgNVBAoMC2V4YW1wbGUuY29tMRQwEgYDVQQDDAtleGFtcGxlLmNvbTAeFw0xMTEwMjIwNjI0MzFaFw0xMjEwMDQwNjI0MzFaMH8xCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRQwEgYDVQQKDAtleGFtcGxlLmNvbTEhMB8GA1UEAwwYTXMuIEJhcmJhcmEgSiBKZW5zZW4gSUlJMSIwIAYJKoZIhvcNAQkBFhNiamVuc2VuQGV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7Kr+Dcds/JQ5GwejJFcBIP682X3xpjis56AK02bc1FLgzdLI8auoR+cC9/Vrh5t66HkQIOdA4unHh0AaZ4xL5PhVbXIPMB5vAPKpzz5iPSi8xO8SL7I7SDhcBVJhqVqr3HgllEG6UClDdHO7nkLuwXq8HcISKkbT5WFTVfFZzidPl8HZ7DhXkZIRtJwBweq4bvm3hM1Os7UQH05ZS6cVDgweKNwdLLrT51ikSQG3DYrl+ft781UQRIqxgwqCfXEuDiinPh0kkvIi5jivVu1Z9QiwlYEdRbLJ4zJQBmDrSGTMYn4lRc2HgHO4DqB/bnMVorHB0CC6AV1QoFK4GPe1LwIDAQABo3sweTAJBgNVHRMEAjAAMCwGCWCGSAGG+EIBDQQfFh1PcGVuU1NMIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQU8pD0U0vsZIsaA16lL8En8bx0F/gwHwYDVR0jBBgwFoAUdGeKitcaF7gnzsNwDx708kqaVt0wDQYJKoZIhvcNAQEFBQADgYEAA81SsFnOdYJtNg5Tcq+/ByEDrBgnusx0jloUhByPMEVkoMZ3J7j1ZgI8rAbOkNngX8+pKfTiDz1RC4+dx8oU6Za+4NJXUjlL5CvV6BEYb1+QAEJwitTVvxB/A67g42/vzgAtoRUeDov1+GFiBZ+GNF/cAYKcMtGcrs2i97ZkJMo=".to_string()), "x509_certificates[0].value did not match expected value");
         let meta = user.meta.unwrap();
-        assert_eq!(meta.resource_type, "User");
-        assert_eq!(meta.created, "2010-01-23T04:56:22Z");
-        assert_eq!(meta.last_modified, "2011-05-13T04:42:34Z");
-        assert_eq!(meta.version, "W/\"a330bc54f0671c9\"");
-        assert_eq!(meta.location, "https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646");
+        assert_eq!(meta.resource_type, Some("User".to_string()));
+        assert_eq!(meta.created, Some("2010-01-23T04:56:22Z".to_string()));
+        assert_eq!(meta.last_modified, Some("2011-05-13T04:42:34Z".to_string()));
+        assert_eq!(meta.version, Some("W/\"a330bc54f0671c9\"".to_string()));
+        assert_eq!(meta.location, Some("https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646".to_string()));
     }
 
     #[test]

--- a/src/schemas/enterprise_user.json
+++ b/src/schemas/enterprise_user.json
@@ -1,115 +1,113 @@
-[
-  {
-    "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
-    "name": "EnterpriseUser",
-    "description": "Enterprise User",
-    "attributes": [
-      {
-        "name": "employeeNumber",
-        "type": "string",
-        "multiValued": false,
-        "description": "Numeric or alphanumeric identifier assigned to a person, typically based on order of hire or association with an organization.",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "costCenter",
-        "type": "string",
-        "multiValued": false,
-        "description": "Identifies the name of a cost center.",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "organization",
-        "type": "string",
-        "multiValued": false,
-        "description": "Identifies the name of an organization.",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "division",
-        "type": "string",
-        "multiValued": false,
-        "description": "Identifies the name of a division.",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "department",
-        "type": "string",
-        "multiValued": false,
-        "description": "Identifies the name of a department.",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "manager",
-        "type": "complex",
-        "multiValued": false,
-        "description": "The User's manager.  A complex type that optionally allows service providers to represent organizational hierarchy by referencing the 'id' attribute of another User.",
-        "required": false,
-        "subAttributes": [
-          {
-            "name": "value",
-            "type": "string",
-            "multiValued": false,
-            "description": "The id of the SCIM resource representing the User's manager.  REQUIRED.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "$ref",
-            "type": "reference",
-            "referenceTypes": [
-              "User"
-            ],
-            "multiValued": false,
-            "description": "The URI of the SCIM resource representing the User's manager.  REQUIRED.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "displayName",
-            "type": "string",
-            "multiValued": false,
-            "description": "The displayName of the User's manager. OPTIONAL and READ-ONLY.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none"
-          }
-        ],
-        "mutability": "readWrite",
-        "returned": "default"
-      }
-    ],
-    "meta": {
-      "resourceType": "Schema",
-      "location": "/v2/Schemas/urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+{
+  "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+  "name": "EnterpriseUser",
+  "description": "Enterprise User",
+  "attributes": [
+    {
+      "name": "employeeNumber",
+      "type": "string",
+      "multiValued": false,
+      "description": "Numeric or alphanumeric identifier assigned to a person, typically based on order of hire or association with an organization.",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "costCenter",
+      "type": "string",
+      "multiValued": false,
+      "description": "Identifies the name of a cost center.",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "organization",
+      "type": "string",
+      "multiValued": false,
+      "description": "Identifies the name of an organization.",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "division",
+      "type": "string",
+      "multiValued": false,
+      "description": "Identifies the name of a division.",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "department",
+      "type": "string",
+      "multiValued": false,
+      "description": "Identifies the name of a department.",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "manager",
+      "type": "complex",
+      "multiValued": false,
+      "description": "The User's manager.  A complex type that optionally allows service providers to represent organizational hierarchy by referencing the 'id' attribute of another User.",
+      "required": false,
+      "subAttributes": [
+        {
+          "name": "value",
+          "type": "string",
+          "multiValued": false,
+          "description": "The id of the SCIM resource representing the User's manager.  REQUIRED.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "$ref",
+          "type": "reference",
+          "referenceTypes": [
+            "User"
+          ],
+          "multiValued": false,
+          "description": "The URI of the SCIM resource representing the User's manager.  REQUIRED.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "displayName",
+          "type": "string",
+          "multiValued": false,
+          "description": "The displayName of the User's manager. OPTIONAL and READ-ONLY.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none"
+        }
+      ],
+      "mutability": "readWrite",
+      "returned": "default"
     }
+  ],
+  "meta": {
+    "resourceType": "Schema",
+    "location": "/v2/Schemas/urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
   }
-]
+}

--- a/src/schemas/group.json
+++ b/src/schemas/group.json
@@ -1,76 +1,74 @@
-[
-  {
-    "id": "urn:ietf:params:scim:schemas:core:2.0:Group",
-    "name": "Group",
-    "description": "Group",
-    "attributes": [
-      {
-        "name": "displayName",
-        "type": "string",
-        "multiValued": false,
-        "description": "A human-readable name for the Group. REQUIRED.",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "members",
-        "type": "complex",
-        "multiValued": true,
-        "description": "A list of members of the Group.",
-        "required": false,
-        "subAttributes": [
-          {
-            "name": "value",
-            "type": "string",
-            "multiValued": false,
-            "description": "Identifier of the member of this Group.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "immutable",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "$ref",
-            "type": "reference",
-            "referenceTypes": [
-              "User",
-              "Group"
-            ],
-            "multiValued": false,
-            "description": "The URI corresponding to a SCIM resource that is a member of this Group.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "immutable",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "type",
-            "type": "string",
-            "multiValued": false,
-            "description": "A label indicating the type of resource, e.g., 'User' or 'Group'.",
-            "required": false,
-            "caseExact": false,
-            "canonicalValues": [
-              "User",
-              "Group"
-            ],
-            "mutability": "immutable",
-            "returned": "default",
-            "uniqueness": "none"
-          }
-        ],
-        "mutability": "readWrite",
-        "returned": "default"
-      }
-    ],
-    "meta": {
-      "resourceType": "Schema",
-      "location": "/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:Group"
+{
+  "id": "urn:ietf:params:scim:schemas:core:2.0:Group",
+  "name": "Group",
+  "description": "Group",
+  "attributes": [
+    {
+      "name": "displayName",
+      "type": "string",
+      "multiValued": false,
+      "description": "A human-readable name for the Group. REQUIRED.",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "members",
+      "type": "complex",
+      "multiValued": true,
+      "description": "A list of members of the Group.",
+      "required": false,
+      "subAttributes": [
+        {
+          "name": "value",
+          "type": "string",
+          "multiValued": false,
+          "description": "Identifier of the member of this Group.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "immutable",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "$ref",
+          "type": "reference",
+          "referenceTypes": [
+            "User",
+            "Group"
+          ],
+          "multiValued": false,
+          "description": "The URI corresponding to a SCIM resource that is a member of this Group.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "immutable",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "multiValued": false,
+          "description": "A label indicating the type of resource, e.g., 'User' or 'Group'.",
+          "required": false,
+          "caseExact": false,
+          "canonicalValues": [
+            "User",
+            "Group"
+          ],
+          "mutability": "immutable",
+          "returned": "default",
+          "uniqueness": "none"
+        }
+      ],
+      "mutability": "readWrite",
+      "returned": "default"
     }
+  ],
+  "meta": {
+    "resourceType": "Schema",
+    "location": "/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:Group"
   }
-]
+}

--- a/src/schemas/resource_type.json
+++ b/src/schemas/resource_type.json
@@ -1,104 +1,102 @@
-[
-  {
-    "id": "urn:ietf:params:scim:schemas:core:2.0:ResourceType",
-    "name": "ResourceType",
-    "description": "Specifies the schema that describes a SCIM resource type",
-    "attributes": [
-      {
-        "name": "id",
-        "type": "string",
-        "multiValued": false,
-        "description": "The resource type's server unique id. May be the same as the 'name' attribute.",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readOnly",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "name",
-        "type": "string",
-        "multiValued": false,
-        "description": "The resource type name.  When applicable, service providers MUST specify the name, e.g., 'User'.",
-        "required": true,
-        "caseExact": false,
-        "mutability": "readOnly",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "description",
-        "type": "string",
-        "multiValued": false,
-        "description": "The resource type's human-readable description.  When applicable, service providers MUST specify the description.",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readOnly",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "endpoint",
-        "type": "reference",
-        "referenceTypes": [
-          "uri"
-        ],
-        "multiValued": false,
-        "description": "The resource type's HTTP-addressable endpoint relative to the Base URL, e.g., '/Users'.",
-        "required": true,
-        "caseExact": false,
-        "mutability": "readOnly",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "schema",
-        "type": "reference",
-        "referenceTypes": [
-          "uri"
-        ],
-        "multiValued": false,
-        "description": "The resource type's primary/base schema URI.",
-        "required": true,
-        "caseExact": true,
-        "mutability": "readOnly",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "schemaExtensions",
-        "type": "complex",
-        "multiValued": false,
-        "description": "A list of URIs of the resource type's schema extensions.",
-        "required": true,
-        "mutability": "readOnly",
-        "returned": "default",
-        "subAttributes": [
-          {
-            "name": "schema",
-            "type": "reference",
-            "referenceTypes": [
-              "uri"
-            ],
-            "multiValued": false,
-            "description": "The URI of a schema extension.",
-            "required": true,
-            "caseExact": true,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "required",
-            "type": "boolean",
-            "multiValued": false,
-            "description": "A Boolean value that specifies whether or not the schema extension is required for the resource type.  If true, a resource of this type MUST include this schema extension and also include any attributes declared as required in this schema extension. If false, a resource of this type MAY omit this schema extension.",
-            "required": true,
-            "mutability": "readOnly",
-            "returned": "default"
-          }
-        ]
-      }
-    ]
-  }
-]
+{
+  "id": "urn:ietf:params:scim:schemas:core:2.0:ResourceType",
+  "name": "ResourceType",
+  "description": "Specifies the schema that describes a SCIM resource type",
+  "attributes": [
+    {
+      "name": "id",
+      "type": "string",
+      "multiValued": false,
+      "description": "The resource type's server unique id. May be the same as the 'name' attribute.",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readOnly",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "multiValued": false,
+      "description": "The resource type name.  When applicable, service providers MUST specify the name, e.g., 'User'.",
+      "required": true,
+      "caseExact": false,
+      "mutability": "readOnly",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "description",
+      "type": "string",
+      "multiValued": false,
+      "description": "The resource type's human-readable description.  When applicable, service providers MUST specify the description.",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readOnly",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "endpoint",
+      "type": "reference",
+      "referenceTypes": [
+        "uri"
+      ],
+      "multiValued": false,
+      "description": "The resource type's HTTP-addressable endpoint relative to the Base URL, e.g., '/Users'.",
+      "required": true,
+      "caseExact": false,
+      "mutability": "readOnly",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "schema",
+      "type": "reference",
+      "referenceTypes": [
+        "uri"
+      ],
+      "multiValued": false,
+      "description": "The resource type's primary/base schema URI.",
+      "required": true,
+      "caseExact": true,
+      "mutability": "readOnly",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "schemaExtensions",
+      "type": "complex",
+      "multiValued": false,
+      "description": "A list of URIs of the resource type's schema extensions.",
+      "required": true,
+      "mutability": "readOnly",
+      "returned": "default",
+      "subAttributes": [
+        {
+          "name": "schema",
+          "type": "reference",
+          "referenceTypes": [
+            "uri"
+          ],
+          "multiValued": false,
+          "description": "The URI of a schema extension.",
+          "required": true,
+          "caseExact": true,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "required",
+          "type": "boolean",
+          "multiValued": false,
+          "description": "A Boolean value that specifies whether or not the schema extension is required for the resource type.  If true, a resource of this type MUST include this schema extension and also include any attributes declared as required in this schema extension. If false, a resource of this type MAY omit this schema extension.",
+          "required": true,
+          "mutability": "readOnly",
+          "returned": "default"
+        }
+      ]
+    }
+  ]
+}

--- a/src/schemas/scim_schema.json
+++ b/src/schemas/scim_schema.json
@@ -1,194 +1,192 @@
-[
-  {
-    "id": "urn:ietf:params:scim:schemas:core:2.0:Schema",
-    "name": "Schema",
-    "description": "Specifies the schema that describes a SCIM schema",
-    "attributes": [
-      {
-        "name": "id",
-        "type": "string",
-        "multiValued": false,
-        "description": "The unique URI of the schema. When applicable, service providers MUST specify the URI.",
-        "required": true,
-        "caseExact": false,
-        "mutability": "readOnly",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "name",
-        "type": "string",
-        "multiValued": false,
-        "description": "The schema's human-readable name.  When applicable, service providers MUST specify the name, e.g., 'User'.",
-        "required": true,
-        "caseExact": false,
-        "mutability": "readOnly",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "description",
-        "type": "string",
-        "multiValued": false,
-        "description": "The schema's human-readable name.  When applicable, service providers MUST specify the name, e.g., 'User'.",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readOnly",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "attributes",
-        "type": "complex",
-        "multiValued": true,
-        "description": "A complex attribute that includes the attributes of a schema.",
-        "required": true,
-        "mutability": "readOnly",
-        "returned": "default",
-        "subAttributes": [
-          {
-            "name": "name",
-            "type": "string",
-            "multiValued": false,
-            "description": "The attribute's name.",
-            "required": true,
-            "caseExact": true,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "type",
-            "type": "string",
-            "multiValued": false,
-            "description": "The attribute's data type. Valid values include 'string', 'complex', 'boolean', 'decimal', 'integer', 'dateTime', 'reference'.",
-            "required": true,
-            "caseExact": false,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none",
-            "canonicalValues": [
-              "string",
-              "complex",
-              "boolean",
-              "decimal",
-              "integer",
-              "dateTime",
-              "reference"
-            ]
-          },
-          {
-            "name": "multiValued",
-            "type": "boolean",
-            "multiValued": false,
-            "description": "A Boolean value indicating an attribute's plurality.",
-            "required": true,
-            "mutability": "readOnly",
-            "returned": "default"
-          },
-          {
-            "name": "description",
-            "type": "string",
-            "multiValued": false,
-            "description": "A human-readable description of the attribute.",
-            "required": false,
-            "caseExact": true,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "required",
-            "type": "boolean",
-            "multiValued": false,
-            "description": "A boolean value indicating whether or not the attribute is required.",
-            "required": false,
-            "mutability": "readOnly",
-            "returned": "default"
-          },
-          {
-            "name": "canonicalValues",
-            "type": "string",
-            "multiValued": true,
-            "description": "A collection of canonical values.  When applicable, service providers MUST specify the canonical types, e.g., 'work', 'home'.",
-            "required": false,
-            "caseExact": true,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "caseExact",
-            "type": "boolean",
-            "multiValued": false,
-            "description": "A Boolean value indicating whether or not a string attribute is case sensitive.",
-            "required": false,
-            "mutability": "readOnly",
-            "returned": "default"
-          },
-          {
-            "name": "mutability",
-            "type": "string",
-            "multiValued": false,
-            "description": "Indicates whether or not an attribute is modifiable.",
-            "required": false,
-            "caseExact": true,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none",
-            "canonicalValues": [
-              "readOnly",
-              "readWrite",
-              "immutable",
-              "writeOnly"
-            ]
-          },
-          {
-            "name": "returned",
-            "type": "string",
-            "multiValued": false,
-            "description": "Indicates when an attribute is returned in a response (e.g., to a query).",
-            "required": false,
-            "caseExact": true,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none",
-            "canonicalValues": [
-              "always",
-              "never",
-              "default",
-              "request"
-            ]
-          },
-          {
-            "name": "uniqueness",
-            "type": "string",
-            "multiValued": false,
-            "description": "Indicates how unique a value must be.",
-            "required": false,
-            "caseExact": true,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none",
-            "canonicalValues": [
-              "none",
-              "server",
-              "global"
-            ]
-          },
-          {
-            "name": "referenceTypes",
-            "type": "string",
-            "multiValued": false,
-            "description": "Used only with an attribute of type 'reference'.  Specifies a SCIM resourceType that a reference attribute MAY refer to, e.g., 'User'.",
-            "required": false,
-            "caseExact": true,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none"
-          }
-        ]
-      }
-    ]
-  }
-]
+{
+  "id": "urn:ietf:params:scim:schemas:core:2.0:Schema",
+  "name": "Schema",
+  "description": "Specifies the schema that describes a SCIM schema",
+  "attributes": [
+    {
+      "name": "id",
+      "type": "string",
+      "multiValued": false,
+      "description": "The unique URI of the schema. When applicable, service providers MUST specify the URI.",
+      "required": true,
+      "caseExact": false,
+      "mutability": "readOnly",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "multiValued": false,
+      "description": "The schema's human-readable name.  When applicable, service providers MUST specify the name, e.g., 'User'.",
+      "required": true,
+      "caseExact": false,
+      "mutability": "readOnly",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "description",
+      "type": "string",
+      "multiValued": false,
+      "description": "The schema's human-readable name.  When applicable, service providers MUST specify the name, e.g., 'User'.",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readOnly",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "attributes",
+      "type": "complex",
+      "multiValued": true,
+      "description": "A complex attribute that includes the attributes of a schema.",
+      "required": true,
+      "mutability": "readOnly",
+      "returned": "default",
+      "subAttributes": [
+        {
+          "name": "name",
+          "type": "string",
+          "multiValued": false,
+          "description": "The attribute's name.",
+          "required": true,
+          "caseExact": true,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "multiValued": false,
+          "description": "The attribute's data type. Valid values include 'string', 'complex', 'boolean', 'decimal', 'integer', 'dateTime', 'reference'.",
+          "required": true,
+          "caseExact": false,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none",
+          "canonicalValues": [
+            "string",
+            "complex",
+            "boolean",
+            "decimal",
+            "integer",
+            "dateTime",
+            "reference"
+          ]
+        },
+        {
+          "name": "multiValued",
+          "type": "boolean",
+          "multiValued": false,
+          "description": "A Boolean value indicating an attribute's plurality.",
+          "required": true,
+          "mutability": "readOnly",
+          "returned": "default"
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "multiValued": false,
+          "description": "A human-readable description of the attribute.",
+          "required": false,
+          "caseExact": true,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "required",
+          "type": "boolean",
+          "multiValued": false,
+          "description": "A boolean value indicating whether or not the attribute is required.",
+          "required": false,
+          "mutability": "readOnly",
+          "returned": "default"
+        },
+        {
+          "name": "canonicalValues",
+          "type": "string",
+          "multiValued": true,
+          "description": "A collection of canonical values.  When applicable, service providers MUST specify the canonical types, e.g., 'work', 'home'.",
+          "required": false,
+          "caseExact": true,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "caseExact",
+          "type": "boolean",
+          "multiValued": false,
+          "description": "A Boolean value indicating whether or not a string attribute is case sensitive.",
+          "required": false,
+          "mutability": "readOnly",
+          "returned": "default"
+        },
+        {
+          "name": "mutability",
+          "type": "string",
+          "multiValued": false,
+          "description": "Indicates whether or not an attribute is modifiable.",
+          "required": false,
+          "caseExact": true,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none",
+          "canonicalValues": [
+            "readOnly",
+            "readWrite",
+            "immutable",
+            "writeOnly"
+          ]
+        },
+        {
+          "name": "returned",
+          "type": "string",
+          "multiValued": false,
+          "description": "Indicates when an attribute is returned in a response (e.g., to a query).",
+          "required": false,
+          "caseExact": true,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none",
+          "canonicalValues": [
+            "always",
+            "never",
+            "default",
+            "request"
+          ]
+        },
+        {
+          "name": "uniqueness",
+          "type": "string",
+          "multiValued": false,
+          "description": "Indicates how unique a value must be.",
+          "required": false,
+          "caseExact": true,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none",
+          "canonicalValues": [
+            "none",
+            "server",
+            "global"
+          ]
+        },
+        {
+          "name": "referenceTypes",
+          "type": "string",
+          "multiValued": false,
+          "description": "Used only with an attribute of type 'reference'.  Specifies a SCIM resourceType that a reference attribute MAY refer to, e.g., 'User'.",
+          "required": false,
+          "caseExact": true,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none"
+        }
+      ]
+    }
+  ]
+}

--- a/src/schemas/service_provider_config.json
+++ b/src/schemas/service_provider_config.json
@@ -1,214 +1,212 @@
-[
-  {
-    "id": "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig",
-    "name": "Service Provider Configuration",
-    "description": "Schema for representing the service provider's configuration",
-    "attributes": [
-      {
-        "name": "documentationUri",
-        "type": "reference",
-        "referenceTypes": [
-          "external"
-        ],
-        "multiValued": false,
-        "description": "An HTTP-addressable URL pointing to the service provider's human-consumable help documentation.",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readOnly",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "patch",
-        "type": "complex",
-        "multiValued": false,
-        "description": "A complex type that specifies PATCH configuration options.",
-        "required": true,
-        "returned": "default",
-        "mutability": "readOnly",
-        "subAttributes": [
-          {
-            "name": "supported",
-            "type": "boolean",
-            "multiValued": false,
-            "description": "A Boolean value specifying whether or not the operation is supported.",
-            "required": true,
-            "mutability": "readOnly",
-            "returned": "default"
-          }
-        ]
-      },
-      {
-        "name": "bulk",
-        "type": "complex",
-        "multiValued": false,
-        "description": "A complex type that specifies bulk configuration options.",
-        "required": true,
-        "returned": "default",
-        "mutability": "readOnly",
-        "subAttributes": [
-          {
-            "name": "supported",
-            "type": "boolean",
-            "multiValued": false,
-            "description": "A Boolean value specifying whether or not the operation is supported.",
-            "required": true,
-            "mutability": "readOnly",
-            "returned": "default"
-          },
-          {
-            "name": "maxOperations",
-            "type": "integer",
-            "multiValued": false,
-            "description": "An integer value specifying the maximum number of operations.",
-            "required": true,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "maxPayloadSize",
-            "type": "integer",
-            "multiValued": false,
-            "description": "An integer value specifying the maximum payload size in bytes.",
-            "required": true,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none"
-          }
-        ]
-      },
-      {
-        "name": "filter",
-        "type": "complex",
-        "multiValued": false,
-        "description": "A complex type that specifies FILTER options.",
-        "required": true,
-        "returned": "default",
-        "mutability": "readOnly",
-        "subAttributes": [
-          {
-            "name": "supported",
-            "type": "boolean",
-            "multiValued": false,
-            "description": "A Boolean value specifying whether or not the operation is supported.",
-            "required": true,
-            "mutability": "readOnly",
-            "returned": "default"
-          },
-          {
-            "name": "maxResults",
-            "type": "integer",
-            "multiValued": false,
-            "description": "An integer value specifying the maximum number of resources returned in a response.",
-            "required": true,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none"
-          }
-        ]
-      },
-      {
-        "name": "changePassword",
-        "type": "complex",
-        "multiValued": false,
-        "description": "A complex type that specifies configuration options related to changing a password.",
-        "required": true,
-        "returned": "default",
-        "mutability": "readOnly",
-        "subAttributes": [
-          {
-            "name": "supported",
-            "type": "boolean",
-            "multiValued": false,
-            "description": "A Boolean value specifying whether or not the operation is supported.",
-            "required": true,
-            "mutability": "readOnly",
-            "returned": "default"
-          }
-        ]
-      },
-      {
-        "name": "sort",
-        "type": "complex",
-        "multiValued": false,
-        "description": "A complex type that specifies sort result options.",
-        "required": true,
-        "returned": "default",
-        "mutability": "readOnly",
-        "subAttributes": [
-          {
-            "name": "supported",
-            "type": "boolean",
-            "multiValued": false,
-            "description": "A Boolean value specifying whether or not the operation is supported.",
-            "required": true,
-            "mutability": "readOnly",
-            "returned": "default"
-          }
-        ]
-      },
-      {
-        "name": "authenticationSchemes",
-        "type": "complex",
-        "multiValued": true,
-        "description": "A complex type that specifies supported authentication scheme properties.",
-        "required": true,
-        "returned": "default",
-        "mutability": "readOnly",
-        "subAttributes": [
-          {
-            "name": "name",
-            "type": "string",
-            "multiValued": false,
-            "description": "The common authentication scheme name, e.g., HTTP Basic.",
-            "required": true,
-            "caseExact": false,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "description",
-            "type": "string",
-            "multiValued": false,
-            "description": "A description of the authentication scheme.",
-            "required": true,
-            "caseExact": false,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "specUri",
-            "type": "reference",
-            "referenceTypes": [
-              "external"
-            ],
-            "multiValued": false,
-            "description": "An HTTP-addressable URL pointing to the authentication scheme's specification.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "documentationUri",
-            "type": "reference",
-            "referenceTypes": [
-              "external"
-            ],
-            "multiValued": false,
-            "description": "An HTTP-addressable URL pointing to the authentication scheme's usage documentation.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none"
-          }
-        ]
-      }
-    ]
-  }
-]
+{
+  "id": "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig",
+  "name": "Service Provider Configuration",
+  "description": "Schema for representing the service provider's configuration",
+  "attributes": [
+    {
+      "name": "documentationUri",
+      "type": "reference",
+      "referenceTypes": [
+        "external"
+      ],
+      "multiValued": false,
+      "description": "An HTTP-addressable URL pointing to the service provider's human-consumable help documentation.",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readOnly",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "patch",
+      "type": "complex",
+      "multiValued": false,
+      "description": "A complex type that specifies PATCH configuration options.",
+      "required": true,
+      "returned": "default",
+      "mutability": "readOnly",
+      "subAttributes": [
+        {
+          "name": "supported",
+          "type": "boolean",
+          "multiValued": false,
+          "description": "A Boolean value specifying whether or not the operation is supported.",
+          "required": true,
+          "mutability": "readOnly",
+          "returned": "default"
+        }
+      ]
+    },
+    {
+      "name": "bulk",
+      "type": "complex",
+      "multiValued": false,
+      "description": "A complex type that specifies bulk configuration options.",
+      "required": true,
+      "returned": "default",
+      "mutability": "readOnly",
+      "subAttributes": [
+        {
+          "name": "supported",
+          "type": "boolean",
+          "multiValued": false,
+          "description": "A Boolean value specifying whether or not the operation is supported.",
+          "required": true,
+          "mutability": "readOnly",
+          "returned": "default"
+        },
+        {
+          "name": "maxOperations",
+          "type": "integer",
+          "multiValued": false,
+          "description": "An integer value specifying the maximum number of operations.",
+          "required": true,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "maxPayloadSize",
+          "type": "integer",
+          "multiValued": false,
+          "description": "An integer value specifying the maximum payload size in bytes.",
+          "required": true,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none"
+        }
+      ]
+    },
+    {
+      "name": "filter",
+      "type": "complex",
+      "multiValued": false,
+      "description": "A complex type that specifies FILTER options.",
+      "required": true,
+      "returned": "default",
+      "mutability": "readOnly",
+      "subAttributes": [
+        {
+          "name": "supported",
+          "type": "boolean",
+          "multiValued": false,
+          "description": "A Boolean value specifying whether or not the operation is supported.",
+          "required": true,
+          "mutability": "readOnly",
+          "returned": "default"
+        },
+        {
+          "name": "maxResults",
+          "type": "integer",
+          "multiValued": false,
+          "description": "An integer value specifying the maximum number of resources returned in a response.",
+          "required": true,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none"
+        }
+      ]
+    },
+    {
+      "name": "changePassword",
+      "type": "complex",
+      "multiValued": false,
+      "description": "A complex type that specifies configuration options related to changing a password.",
+      "required": true,
+      "returned": "default",
+      "mutability": "readOnly",
+      "subAttributes": [
+        {
+          "name": "supported",
+          "type": "boolean",
+          "multiValued": false,
+          "description": "A Boolean value specifying whether or not the operation is supported.",
+          "required": true,
+          "mutability": "readOnly",
+          "returned": "default"
+        }
+      ]
+    },
+    {
+      "name": "sort",
+      "type": "complex",
+      "multiValued": false,
+      "description": "A complex type that specifies sort result options.",
+      "required": true,
+      "returned": "default",
+      "mutability": "readOnly",
+      "subAttributes": [
+        {
+          "name": "supported",
+          "type": "boolean",
+          "multiValued": false,
+          "description": "A Boolean value specifying whether or not the operation is supported.",
+          "required": true,
+          "mutability": "readOnly",
+          "returned": "default"
+        }
+      ]
+    },
+    {
+      "name": "authenticationSchemes",
+      "type": "complex",
+      "multiValued": true,
+      "description": "A complex type that specifies supported authentication scheme properties.",
+      "required": true,
+      "returned": "default",
+      "mutability": "readOnly",
+      "subAttributes": [
+        {
+          "name": "name",
+          "type": "string",
+          "multiValued": false,
+          "description": "The common authentication scheme name, e.g., HTTP Basic.",
+          "required": true,
+          "caseExact": false,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "multiValued": false,
+          "description": "A description of the authentication scheme.",
+          "required": true,
+          "caseExact": false,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "specUri",
+          "type": "reference",
+          "referenceTypes": [
+            "external"
+          ],
+          "multiValued": false,
+          "description": "An HTTP-addressable URL pointing to the authentication scheme's specification.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "documentationUri",
+          "type": "reference",
+          "referenceTypes": [
+            "external"
+          ],
+          "multiValued": false,
+          "description": "An HTTP-addressable URL pointing to the authentication scheme's usage documentation.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none"
+        }
+      ]
+    }
+  ]
+}

--- a/src/schemas/user.json
+++ b/src/schemas/user.json
@@ -1,775 +1,773 @@
-[
-  {
-    "id": "urn:ietf:params:scim:schemas:core:2.0:User",
-    "name": "User",
-    "description": "User Account",
-    "attributes": [
-      {
-        "name": "userName",
-        "type": "string",
-        "multiValued": false,
-        "description": "Unique identifier for the User, typically used by the user to directly authenticate to the service provider. Each User MUST include a non-empty userName value.  This identifier MUST be unique across the service provider's entire set of Users. REQUIRED.",
-        "required": true,
-        "caseExact": false,
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "server"
-      },
-      {
-        "name": "name",
-        "type": "complex",
-        "multiValued": false,
-        "description": "The components of the user's real name. Providers MAY return just the full name as a single string in the formatted sub-attribute, or they MAY return just the individual component attributes using the other sub-attributes, or they MAY return both.  If both variants are returned, they SHOULD be describing the same name, with the formatted name indicating how the component attributes should be combined.",
-        "required": false,
-        "subAttributes": [
-          {
-            "name": "formatted",
-            "type": "string",
-            "multiValued": false,
-            "description": "The full name, including all middle names, titles, and suffixes as appropriate, formatted for display (e.g., 'Ms. Barbara J Jensen, III').",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "familyName",
-            "type": "string",
-            "multiValued": false,
-            "description": "The family name of the User, or last name in most Western languages (e.g., 'Jensen' given the full name 'Ms. Barbara J Jensen, III').",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "givenName",
-            "type": "string",
-            "multiValued": false,
-            "description": "The given name of the User, or first name in most Western languages (e.g., 'Barbara' given the full name 'Ms. Barbara J Jensen, III').",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "middleName",
-            "type": "string",
-            "multiValued": false,
-            "description": "The middle name(s) of the User (e.g., 'Jane' given the full name 'Ms. Barbara J Jensen, III').",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "honorificPrefix",
-            "type": "string",
-            "multiValued": false,
-            "description": "The honorific prefix(es) of the User, or title in most Western languages (e.g., 'Ms.' given the full name 'Ms. Barbara J Jensen, III').",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "honorificSuffix",
-            "type": "string",
-            "multiValued": false,
-            "description": "The honorific suffix(es) of the User, or suffix in most Western languages (e.g., 'III' given the full name 'Ms. Barbara J Jensen, III').",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          }
-        ],
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "displayName",
-        "type": "string",
-        "multiValued": false,
-        "description": "The name of the User, suitable for display to end-users.  The name SHOULD be the full name of the User being described, if known.",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "nickName",
-        "type": "string",
-        "multiValued": false,
-        "description": "The casual way to address the user in real life, e.g., 'Bob' or 'Bobby' instead of 'Robert'.  This attribute SHOULD NOT be used to represent a User's username (e.g., 'bjensen' or 'mpepperidge').",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "profileUrl",
-        "type": "reference",
-        "referenceTypes": [
-          "external"
-        ],
-        "multiValued": false,
-        "description": "A fully qualified URL pointing to a page representing the User's online profile.",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "title",
-        "type": "string",
-        "multiValued": false,
-        "description": "The user's title, such as \"Vice President.\"",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "userType",
-        "type": "string",
-        "multiValued": false,
-        "description": "Used to identify the relationship between the organization and the user.  Typical values used might be 'Contractor', 'Employee', 'Intern', 'Temp', 'External', and 'Unknown', but any value may be used.",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "preferredLanguage",
-        "type": "string",
-        "multiValued": false,
-        "description": "Indicates the User's preferred written or spoken language.  Generally used for selecting a localized user interface; e.g., 'en_US' specifies the language English and country US.",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "locale",
-        "type": "string",
-        "multiValued": false,
-        "description": "Used to indicate the User's default location for purposes of localizing items such as currency, date time format, or numerical representations.",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "timezone",
-        "type": "string",
-        "multiValued": false,
-        "description": "The User's time zone in the 'Olson' time zone database format, e.g., 'America/Los_Angeles'.",
-        "required": false,
-        "caseExact": false,
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "active",
-        "type": "boolean",
-        "multiValued": false,
-        "description": "A Boolean value indicating the User's administrative status.",
-        "required": false,
-        "mutability": "readWrite",
-        "returned": "default"
-      },
-      {
-        "name": "password",
-        "type": "string",
-        "multiValued": false,
-        "description": "The User's cleartext password.  This attribute is intended to be used as a means to specify an initial password when creating a new User or to reset an existing User's password.",
-        "required": false,
-        "caseExact": false,
-        "mutability": "writeOnly",
-        "returned": "never",
-        "uniqueness": "none"
-      },
-      {
-        "name": "emails",
-        "type": "complex",
-        "multiValued": true,
-        "description": "Email addresses for the user.  The value SHOULD be canonicalized by the service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'. Canonical type values of 'work', 'home', and 'other'.",
-        "required": false,
-        "subAttributes": [
-          {
-            "name": "value",
-            "type": "string",
-            "multiValued": false,
-            "description": "Email addresses for the user.  The value SHOULD be canonicalized by the service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'. Canonical type values of 'work', 'home', and 'other'.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "display",
-            "type": "string",
-            "multiValued": false,
-            "description": "A human-readable name, primarily used for display purposes.  READ-ONLY.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "type",
-            "type": "string",
-            "multiValued": false,
-            "description": "A label indicating the attribute's function, e.g., 'work' or 'home'.",
-            "required": false,
-            "caseExact": false,
-            "canonicalValues": [
-              "work",
-              "home",
-              "other"
-            ],
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "primary",
-            "type": "boolean",
-            "multiValued": false,
-            "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g., the preferred mailing address or primary email address.  The primary attribute value 'true' MUST appear no more than once.",
-            "required": false,
-            "mutability": "readWrite",
-            "returned": "default"
-          }
-        ],
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "phoneNumbers",
-        "type": "complex",
-        "multiValued": true,
-        "description": "Phone numbers for the User.  The value SHOULD be canonicalized by the service provider according to the format specified in RFC 3966, e.g., 'tel:+1-201-555-0123'. Canonical type values of 'work', 'home', 'mobile', 'fax', 'pager', and 'other'.",
-        "required": false,
-        "subAttributes": [
-          {
-            "name": "value",
-            "type": "string",
-            "multiValued": false,
-            "description": "Phone number of the User.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "display",
-            "type": "string",
-            "multiValued": false,
-            "description": "A human-readable name, primarily used for display purposes.  READ-ONLY.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "type",
-            "type": "string",
-            "multiValued": false,
-            "description": "A label indicating the attribute's function, e.g., 'work', 'home', 'mobile'.",
-            "required": false,
-            "caseExact": false,
-            "canonicalValues": [
-              "work",
-              "home",
-              "mobile",
-              "fax",
-              "pager",
-              "other"
-            ],
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "primary",
-            "type": "boolean",
-            "multiValued": false,
-            "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g., the preferred phone number or primary phone number.  The primary attribute value 'true' MUST appear no more than once.",
-            "required": false,
-            "mutability": "readWrite",
-            "returned": "default"
-          }
-        ],
-        "mutability": "readWrite",
-        "returned": "default"
-      },
-      {
-        "name": "ims",
-        "type": "complex",
-        "multiValued": true,
-        "description": "Instant messaging addresses for the User.",
-        "required": false,
-        "subAttributes": [
-          {
-            "name": "value",
-            "type": "string",
-            "multiValued": false,
-            "description": "Instant messaging address for the User.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "display",
-            "type": "string",
-            "multiValued": false,
-            "description": "A human-readable name, primarily used for display purposes.  READ-ONLY.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "type",
-            "type": "string",
-            "multiValued": false,
-            "description": "A label indicating the attribute's function, e.g., 'aim', 'gtalk', 'xmpp'.",
-            "required": false,
-            "caseExact": false,
-            "canonicalValues": [
-              "aim",
-              "gtalk",
-              "icq",
-              "xmpp",
-              "msn",
-              "skype",
-              "qq",
-              "yahoo"
-            ],
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "primary",
-            "type": "boolean",
-            "multiValued": false,
-            "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g., the preferred messenger or primary messenger.  The primary attribute value 'true' MUST appear no more than once.",
-            "required": false,
-            "mutability": "readWrite",
-            "returned": "default"
-          }
-        ],
-        "mutability": "readWrite",
-        "returned": "default"
-      },
-      {
-        "name": "photos",
-        "type": "complex",
-        "multiValued": true,
-        "description": "URLs of photos of the User.",
-        "required": false,
-        "subAttributes": [
-          {
-            "name": "value",
-            "type": "reference",
-            "referenceTypes": [
-              "external"
-            ],
-            "multiValued": false,
-            "description": "URL of a photo of the User.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "display",
-            "type": "string",
-            "multiValued": false,
-            "description": "A human-readable name, primarily used for display purposes.  READ-ONLY.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "type",
-            "type": "string",
-            "multiValued": false,
-            "description": "A label indicating the attribute's function, i.e., 'photo' or 'thumbnail'.",
-            "required": false,
-            "caseExact": false,
-            "canonicalValues": [
-              "photo",
-              "thumbnail"
-            ],
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "primary",
-            "type": "boolean",
-            "multiValued": false,
-            "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g., the preferred photo or thumbnail.  The primary attribute value 'true' MUST appear no more than once.",
-            "required": false,
-            "mutability": "readWrite",
-            "returned": "default"
-          }
-        ],
-        "mutability": "readWrite",
-        "returned": "default"
-      },
-      {
-        "name": "addresses",
-        "type": "complex",
-        "multiValued": true,
-        "description": "A physical mailing address for this User. Canonical type values of 'work', 'home', and 'other'.  This attribute is a complex type with the following sub-attributes.",
-        "required": false,
-        "subAttributes": [
-          {
-            "name": "formatted",
-            "type": "string",
-            "multiValued": false,
-            "description": "The full mailing address, formatted for display or use with a mailing label.  This attribute MAY contain newlines.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "streetAddress",
-            "type": "string",
-            "multiValued": false,
-            "description": "The full street address component, which may include house number, street name, P.O. box, and multi-line extended street address information.  This attribute MAY contain newlines.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "locality",
-            "type": "string",
-            "multiValued": false,
-            "description": "The city or locality component.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "region",
-            "type": "string",
-            "multiValued": false,
-            "description": "The state or region component.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "postalCode",
-            "type": "string",
-            "multiValued": false,
-            "description": "The zip code or postal code component.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "country",
-            "type": "string",
-            "multiValued": false,
-            "description": "The country name component.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "type",
-            "type": "string",
-            "multiValued": false,
-            "description": "A label indicating the attribute's function, e.g., 'work' or 'home'.",
-            "required": false,
-            "caseExact": false,
-            "canonicalValues": [
-              "work",
-              "home",
-              "other"
-            ],
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          }
-        ],
-        "mutability": "readWrite",
-        "returned": "default",
-        "uniqueness": "none"
-      },
-      {
-        "name": "groups",
-        "type": "complex",
-        "multiValued": true,
-        "description": "A list of groups to which the user belongs, either through direct membership, through nested groups, or dynamically calculated.",
-        "required": false,
-        "subAttributes": [
-          {
-            "name": "value",
-            "type": "string",
-            "multiValued": false,
-            "description": "The identifier of the User's group.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "$ref",
-            "type": "reference",
-            "referenceTypes": [
-              "User",
-              "Group"
-            ],
-            "multiValued": false,
-            "description": "The URI of the corresponding 'Group' resource to which the user belongs.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "display",
-            "type": "string",
-            "multiValued": false,
-            "description": "A human-readable name, primarily used for display purposes.  READ-ONLY.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "type",
-            "type": "string",
-            "multiValued": false,
-            "description": "A label indicating the attribute's function, e.g., 'direct' or 'indirect'.",
-            "required": false,
-            "caseExact": false,
-            "canonicalValues": [
-              "direct",
-              "indirect"
-            ],
-            "mutability": "readOnly",
-            "returned": "default",
-            "uniqueness": "none"
-          }
-        ],
-        "mutability": "readOnly",
-        "returned": "default"
-      },
-      {
-        "name": "entitlements",
-        "type": "complex",
-        "multiValued": true,
-        "description": "A list of entitlements for the User that represent a thing the User has.",
-        "required": false,
-        "subAttributes": [
-          {
-            "name": "value",
-            "type": "string",
-            "multiValued": false,
-            "description": "The value of an entitlement.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "display",
-            "type": "string",
-            "multiValued": false,
-            "description": "A human-readable name, primarily used for display purposes.  READ-ONLY.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "type",
-            "type": "string",
-            "multiValued": false,
-            "description": "A label indicating the attribute's function.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "primary",
-            "type": "boolean",
-            "multiValued": false,
-            "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute.  The primary attribute value 'true' MUST appear no more than once.",
-            "required": false,
-            "mutability": "readWrite",
-            "returned": "default"
-          }
-        ],
-        "mutability": "readWrite",
-        "returned": "default"
-      },
-      {
-        "name": "roles",
-        "type": "complex",
-        "multiValued": true,
-        "description": "A list of roles for the User that collectively represent who the User is, e.g., 'Student', 'Faculty'.",
-        "required": false,
-        "subAttributes": [
-          {
-            "name": "value",
-            "type": "string",
-            "multiValued": false,
-            "description": "The value of a role.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "display",
-            "type": "string",
-            "multiValued": false,
-            "description": "A human-readable name, primarily used for display purposes.  READ-ONLY.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "type",
-            "type": "string",
-            "multiValued": false,
-            "description": "A label indicating the attribute's function.",
-            "required": false,
-            "caseExact": false,
-            "canonicalValues": [],
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "primary",
-            "type": "boolean",
-            "multiValued": false,
-            "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute.  The primary attribute value 'true' MUST appear no more than once.",
-            "required": false,
-            "mutability": "readWrite",
-            "returned": "default"
-          }
-        ],
-        "mutability": "readWrite",
-        "returned": "default"
-      },
-      {
-        "name": "x509Certificates",
-        "type": "complex",
-        "multiValued": true,
-        "description": "A list of certificates issued to the User.",
-        "required": false,
-        "caseExact": false,
-        "subAttributes": [
-          {
-            "name": "value",
-            "type": "binary",
-            "multiValued": false,
-            "description": "The value of an X.509 certificate.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "display",
-            "type": "string",
-            "multiValued": false,
-            "description": "A human-readable name, primarily used for display purposes.  READ-ONLY.",
-            "required": false,
-            "caseExact": false,
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "type",
-            "type": "string",
-            "multiValued": false,
-            "description": "A label indicating the attribute's function.",
-            "required": false,
-            "caseExact": false,
-            "canonicalValues": [],
-            "mutability": "readWrite",
-            "returned": "default",
-            "uniqueness": "none"
-          },
-          {
-            "name": "primary",
-            "type": "boolean",
-            "multiValued": false,
-            "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute.  The primary attribute value 'true' MUST appear no more than once.",
-            "required": false,
-            "mutability": "readWrite",
-            "returned": "default"
-          }
-        ],
-        "mutability": "readWrite",
-        "returned": "default"
-      }
-    ],
-    "meta": {
-      "resourceType": "Schema",
-      "location": "/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User"
+{
+  "id": "urn:ietf:params:scim:schemas:core:2.0:User",
+  "name": "User",
+  "description": "User Account",
+  "attributes": [
+    {
+      "name": "userName",
+      "type": "string",
+      "multiValued": false,
+      "description": "Unique identifier for the User, typically used by the user to directly authenticate to the service provider. Each User MUST include a non-empty userName value.  This identifier MUST be unique across the service provider's entire set of Users. REQUIRED.",
+      "required": true,
+      "caseExact": false,
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "server"
+    },
+    {
+      "name": "name",
+      "type": "complex",
+      "multiValued": false,
+      "description": "The components of the user's real name. Providers MAY return just the full name as a single string in the formatted sub-attribute, or they MAY return just the individual component attributes using the other sub-attributes, or they MAY return both.  If both variants are returned, they SHOULD be describing the same name, with the formatted name indicating how the component attributes should be combined.",
+      "required": false,
+      "subAttributes": [
+        {
+          "name": "formatted",
+          "type": "string",
+          "multiValued": false,
+          "description": "The full name, including all middle names, titles, and suffixes as appropriate, formatted for display (e.g., 'Ms. Barbara J Jensen, III').",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "familyName",
+          "type": "string",
+          "multiValued": false,
+          "description": "The family name of the User, or last name in most Western languages (e.g., 'Jensen' given the full name 'Ms. Barbara J Jensen, III').",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "givenName",
+          "type": "string",
+          "multiValued": false,
+          "description": "The given name of the User, or first name in most Western languages (e.g., 'Barbara' given the full name 'Ms. Barbara J Jensen, III').",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "middleName",
+          "type": "string",
+          "multiValued": false,
+          "description": "The middle name(s) of the User (e.g., 'Jane' given the full name 'Ms. Barbara J Jensen, III').",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "honorificPrefix",
+          "type": "string",
+          "multiValued": false,
+          "description": "The honorific prefix(es) of the User, or title in most Western languages (e.g., 'Ms.' given the full name 'Ms. Barbara J Jensen, III').",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "honorificSuffix",
+          "type": "string",
+          "multiValued": false,
+          "description": "The honorific suffix(es) of the User, or suffix in most Western languages (e.g., 'III' given the full name 'Ms. Barbara J Jensen, III').",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        }
+      ],
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "displayName",
+      "type": "string",
+      "multiValued": false,
+      "description": "The name of the User, suitable for display to end-users.  The name SHOULD be the full name of the User being described, if known.",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "nickName",
+      "type": "string",
+      "multiValued": false,
+      "description": "The casual way to address the user in real life, e.g., 'Bob' or 'Bobby' instead of 'Robert'.  This attribute SHOULD NOT be used to represent a User's username (e.g., 'bjensen' or 'mpepperidge').",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "profileUrl",
+      "type": "reference",
+      "referenceTypes": [
+        "external"
+      ],
+      "multiValued": false,
+      "description": "A fully qualified URL pointing to a page representing the User's online profile.",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "title",
+      "type": "string",
+      "multiValued": false,
+      "description": "The user's title, such as \"Vice President.\"",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "userType",
+      "type": "string",
+      "multiValued": false,
+      "description": "Used to identify the relationship between the organization and the user.  Typical values used might be 'Contractor', 'Employee', 'Intern', 'Temp', 'External', and 'Unknown', but any value may be used.",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "preferredLanguage",
+      "type": "string",
+      "multiValued": false,
+      "description": "Indicates the User's preferred written or spoken language.  Generally used for selecting a localized user interface; e.g., 'en_US' specifies the language English and country US.",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "locale",
+      "type": "string",
+      "multiValued": false,
+      "description": "Used to indicate the User's default location for purposes of localizing items such as currency, date time format, or numerical representations.",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "timezone",
+      "type": "string",
+      "multiValued": false,
+      "description": "The User's time zone in the 'Olson' time zone database format, e.g., 'America/Los_Angeles'.",
+      "required": false,
+      "caseExact": false,
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "active",
+      "type": "boolean",
+      "multiValued": false,
+      "description": "A Boolean value indicating the User's administrative status.",
+      "required": false,
+      "mutability": "readWrite",
+      "returned": "default"
+    },
+    {
+      "name": "password",
+      "type": "string",
+      "multiValued": false,
+      "description": "The User's cleartext password.  This attribute is intended to be used as a means to specify an initial password when creating a new User or to reset an existing User's password.",
+      "required": false,
+      "caseExact": false,
+      "mutability": "writeOnly",
+      "returned": "never",
+      "uniqueness": "none"
+    },
+    {
+      "name": "emails",
+      "type": "complex",
+      "multiValued": true,
+      "description": "Email addresses for the user.  The value SHOULD be canonicalized by the service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'. Canonical type values of 'work', 'home', and 'other'.",
+      "required": false,
+      "subAttributes": [
+        {
+          "name": "value",
+          "type": "string",
+          "multiValued": false,
+          "description": "Email addresses for the user.  The value SHOULD be canonicalized by the service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'. Canonical type values of 'work', 'home', and 'other'.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "display",
+          "type": "string",
+          "multiValued": false,
+          "description": "A human-readable name, primarily used for display purposes.  READ-ONLY.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "multiValued": false,
+          "description": "A label indicating the attribute's function, e.g., 'work' or 'home'.",
+          "required": false,
+          "caseExact": false,
+          "canonicalValues": [
+            "work",
+            "home",
+            "other"
+          ],
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "primary",
+          "type": "boolean",
+          "multiValued": false,
+          "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g., the preferred mailing address or primary email address.  The primary attribute value 'true' MUST appear no more than once.",
+          "required": false,
+          "mutability": "readWrite",
+          "returned": "default"
+        }
+      ],
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "phoneNumbers",
+      "type": "complex",
+      "multiValued": true,
+      "description": "Phone numbers for the User.  The value SHOULD be canonicalized by the service provider according to the format specified in RFC 3966, e.g., 'tel:+1-201-555-0123'. Canonical type values of 'work', 'home', 'mobile', 'fax', 'pager', and 'other'.",
+      "required": false,
+      "subAttributes": [
+        {
+          "name": "value",
+          "type": "string",
+          "multiValued": false,
+          "description": "Phone number of the User.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "display",
+          "type": "string",
+          "multiValued": false,
+          "description": "A human-readable name, primarily used for display purposes.  READ-ONLY.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "multiValued": false,
+          "description": "A label indicating the attribute's function, e.g., 'work', 'home', 'mobile'.",
+          "required": false,
+          "caseExact": false,
+          "canonicalValues": [
+            "work",
+            "home",
+            "mobile",
+            "fax",
+            "pager",
+            "other"
+          ],
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "primary",
+          "type": "boolean",
+          "multiValued": false,
+          "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g., the preferred phone number or primary phone number.  The primary attribute value 'true' MUST appear no more than once.",
+          "required": false,
+          "mutability": "readWrite",
+          "returned": "default"
+        }
+      ],
+      "mutability": "readWrite",
+      "returned": "default"
+    },
+    {
+      "name": "ims",
+      "type": "complex",
+      "multiValued": true,
+      "description": "Instant messaging addresses for the User.",
+      "required": false,
+      "subAttributes": [
+        {
+          "name": "value",
+          "type": "string",
+          "multiValued": false,
+          "description": "Instant messaging address for the User.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "display",
+          "type": "string",
+          "multiValued": false,
+          "description": "A human-readable name, primarily used for display purposes.  READ-ONLY.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "multiValued": false,
+          "description": "A label indicating the attribute's function, e.g., 'aim', 'gtalk', 'xmpp'.",
+          "required": false,
+          "caseExact": false,
+          "canonicalValues": [
+            "aim",
+            "gtalk",
+            "icq",
+            "xmpp",
+            "msn",
+            "skype",
+            "qq",
+            "yahoo"
+          ],
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "primary",
+          "type": "boolean",
+          "multiValued": false,
+          "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g., the preferred messenger or primary messenger.  The primary attribute value 'true' MUST appear no more than once.",
+          "required": false,
+          "mutability": "readWrite",
+          "returned": "default"
+        }
+      ],
+      "mutability": "readWrite",
+      "returned": "default"
+    },
+    {
+      "name": "photos",
+      "type": "complex",
+      "multiValued": true,
+      "description": "URLs of photos of the User.",
+      "required": false,
+      "subAttributes": [
+        {
+          "name": "value",
+          "type": "reference",
+          "referenceTypes": [
+            "external"
+          ],
+          "multiValued": false,
+          "description": "URL of a photo of the User.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "display",
+          "type": "string",
+          "multiValued": false,
+          "description": "A human-readable name, primarily used for display purposes.  READ-ONLY.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "multiValued": false,
+          "description": "A label indicating the attribute's function, i.e., 'photo' or 'thumbnail'.",
+          "required": false,
+          "caseExact": false,
+          "canonicalValues": [
+            "photo",
+            "thumbnail"
+          ],
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "primary",
+          "type": "boolean",
+          "multiValued": false,
+          "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g., the preferred photo or thumbnail.  The primary attribute value 'true' MUST appear no more than once.",
+          "required": false,
+          "mutability": "readWrite",
+          "returned": "default"
+        }
+      ],
+      "mutability": "readWrite",
+      "returned": "default"
+    },
+    {
+      "name": "addresses",
+      "type": "complex",
+      "multiValued": true,
+      "description": "A physical mailing address for this User. Canonical type values of 'work', 'home', and 'other'.  This attribute is a complex type with the following sub-attributes.",
+      "required": false,
+      "subAttributes": [
+        {
+          "name": "formatted",
+          "type": "string",
+          "multiValued": false,
+          "description": "The full mailing address, formatted for display or use with a mailing label.  This attribute MAY contain newlines.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "streetAddress",
+          "type": "string",
+          "multiValued": false,
+          "description": "The full street address component, which may include house number, street name, P.O. box, and multi-line extended street address information.  This attribute MAY contain newlines.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "locality",
+          "type": "string",
+          "multiValued": false,
+          "description": "The city or locality component.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "region",
+          "type": "string",
+          "multiValued": false,
+          "description": "The state or region component.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "postalCode",
+          "type": "string",
+          "multiValued": false,
+          "description": "The zip code or postal code component.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "country",
+          "type": "string",
+          "multiValued": false,
+          "description": "The country name component.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "multiValued": false,
+          "description": "A label indicating the attribute's function, e.g., 'work' or 'home'.",
+          "required": false,
+          "caseExact": false,
+          "canonicalValues": [
+            "work",
+            "home",
+            "other"
+          ],
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        }
+      ],
+      "mutability": "readWrite",
+      "returned": "default",
+      "uniqueness": "none"
+    },
+    {
+      "name": "groups",
+      "type": "complex",
+      "multiValued": true,
+      "description": "A list of groups to which the user belongs, either through direct membership, through nested groups, or dynamically calculated.",
+      "required": false,
+      "subAttributes": [
+        {
+          "name": "value",
+          "type": "string",
+          "multiValued": false,
+          "description": "The identifier of the User's group.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "$ref",
+          "type": "reference",
+          "referenceTypes": [
+            "User",
+            "Group"
+          ],
+          "multiValued": false,
+          "description": "The URI of the corresponding 'Group' resource to which the user belongs.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "display",
+          "type": "string",
+          "multiValued": false,
+          "description": "A human-readable name, primarily used for display purposes.  READ-ONLY.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "multiValued": false,
+          "description": "A label indicating the attribute's function, e.g., 'direct' or 'indirect'.",
+          "required": false,
+          "caseExact": false,
+          "canonicalValues": [
+            "direct",
+            "indirect"
+          ],
+          "mutability": "readOnly",
+          "returned": "default",
+          "uniqueness": "none"
+        }
+      ],
+      "mutability": "readOnly",
+      "returned": "default"
+    },
+    {
+      "name": "entitlements",
+      "type": "complex",
+      "multiValued": true,
+      "description": "A list of entitlements for the User that represent a thing the User has.",
+      "required": false,
+      "subAttributes": [
+        {
+          "name": "value",
+          "type": "string",
+          "multiValued": false,
+          "description": "The value of an entitlement.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "display",
+          "type": "string",
+          "multiValued": false,
+          "description": "A human-readable name, primarily used for display purposes.  READ-ONLY.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "multiValued": false,
+          "description": "A label indicating the attribute's function.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "primary",
+          "type": "boolean",
+          "multiValued": false,
+          "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute.  The primary attribute value 'true' MUST appear no more than once.",
+          "required": false,
+          "mutability": "readWrite",
+          "returned": "default"
+        }
+      ],
+      "mutability": "readWrite",
+      "returned": "default"
+    },
+    {
+      "name": "roles",
+      "type": "complex",
+      "multiValued": true,
+      "description": "A list of roles for the User that collectively represent who the User is, e.g., 'Student', 'Faculty'.",
+      "required": false,
+      "subAttributes": [
+        {
+          "name": "value",
+          "type": "string",
+          "multiValued": false,
+          "description": "The value of a role.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "display",
+          "type": "string",
+          "multiValued": false,
+          "description": "A human-readable name, primarily used for display purposes.  READ-ONLY.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "multiValued": false,
+          "description": "A label indicating the attribute's function.",
+          "required": false,
+          "caseExact": false,
+          "canonicalValues": [],
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "primary",
+          "type": "boolean",
+          "multiValued": false,
+          "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute.  The primary attribute value 'true' MUST appear no more than once.",
+          "required": false,
+          "mutability": "readWrite",
+          "returned": "default"
+        }
+      ],
+      "mutability": "readWrite",
+      "returned": "default"
+    },
+    {
+      "name": "x509Certificates",
+      "type": "complex",
+      "multiValued": true,
+      "description": "A list of certificates issued to the User.",
+      "required": false,
+      "caseExact": false,
+      "subAttributes": [
+        {
+          "name": "value",
+          "type": "binary",
+          "multiValued": false,
+          "description": "The value of an X.509 certificate.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "display",
+          "type": "string",
+          "multiValued": false,
+          "description": "A human-readable name, primarily used for display purposes.  READ-ONLY.",
+          "required": false,
+          "caseExact": false,
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "multiValued": false,
+          "description": "A label indicating the attribute's function.",
+          "required": false,
+          "caseExact": false,
+          "canonicalValues": [],
+          "mutability": "readWrite",
+          "returned": "default",
+          "uniqueness": "none"
+        },
+        {
+          "name": "primary",
+          "type": "boolean",
+          "multiValued": false,
+          "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute.  The primary attribute value 'true' MUST appear no more than once.",
+          "required": false,
+          "mutability": "readWrite",
+          "returned": "default"
+        }
+      ],
+      "mutability": "readWrite",
+      "returned": "default"
     }
+  ],
+  "meta": {
+    "resourceType": "Schema",
+    "location": "/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User"
   }
-]
+}

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -8,6 +8,7 @@ pub enum SCIMError {
     InvalidJsonFormat,
     MissingRequiredField(String),
     InvalidFieldValue(String),
+    SchemaNotFound(String),
 }
 
 
@@ -19,6 +20,13 @@ impl Display for SCIMError {
             SCIMError::InvalidJsonFormat => write!(f, "Invalid JSON format"),
             SCIMError::MissingRequiredField(field) => write!(f, "Missing required field: {}", field),
             SCIMError::InvalidFieldValue(field) => write!(f, "Invalid field value: {}", field),
+            SCIMError::SchemaNotFound(field) => write!(f, "Schema not found: {}", field),
         }
+    }
+}
+
+impl From<serde_json::Error> for SCIMError {
+    fn from(err: serde_json::Error) -> SCIMError {
+        SCIMError::DeserializationError(err)
     }
 }


### PR DESCRIPTION
Adds logic for scim_schema and creates all the structs. We also expose a function to query and return the schem for user, enterprise_user, and groups so the user can modify and return them in their SCIM server implementation.