### PR TITLE
Add patchOp Structs & make ListQuery flexible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scim_v2"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Dan Gericke <dan@shiftcontrol.io>"]
 description = "A crate that provides utilities for working with the System for Cross-domain Identity Management (SCIM) version 2.0 protocol. (rfc7642, rfc7643, rfc7644)"
@@ -13,7 +13,6 @@ rust-version = "1.56"
 [dependencies]
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
-log = "0.4.21"
 
 [dev-dependencies]
 automod = "1.0.14"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To use \`scim_v2\` in your project, add the following to your \`Cargo.toml\`:
 
 ```toml
 [dependencies]
-scim_v2 = "0.2.0"
+scim_v2 = "0.2.1"
 ```
 
 Then run \`cargo build\` to download and compile the \`scim_v2\` crate and all its dependencies.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,10 +78,6 @@
 //! For more examples and usage details, refer to the documentation of each function and struct.
 
 
-/// External crate imports
-extern crate serde;
-extern crate serde_json;
-
 // Include the schema files into the binary.
 const USER_SCHEMA: &str = include_str!("schemas/user.json");
 const GROUP_SCHEMA: &str = include_str!("schemas/group.json");

--- a/src/models/others.rs
+++ b/src/models/others.rs
@@ -96,7 +96,7 @@ impl Default for ListResponse {
 
 
 #[derive(Serialize, Deserialize, Debug)]
-struct PatchOp {
+pub struct PatchOp {
     pub schemas: Vec<String>,
     #[serde(rename = "Operations")]
     pub operations: Vec<PatchOperations>,
@@ -112,7 +112,7 @@ impl Default for PatchOp {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct PatchOperations {
+pub struct PatchOperations {
     pub op: String,
     pub value: PatchOpValue,
 }
@@ -128,7 +128,7 @@ impl Default for PatchOperations {
 
 #[derive(Default)]
 #[derive(Serialize, Deserialize, Debug)]
-struct PatchOpValue {
+pub struct PatchOpValue {
     pub attributes: HashMap<String, Value>,
 }
 

--- a/src/models/others.rs
+++ b/src/models/others.rs
@@ -36,7 +36,7 @@ pub struct ListQuery {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter: Option<String>,
     #[serde(rename = "startIndex", skip_serializing_if = "Option::is_none")]
-    pub start_index: Some(i64),
+    pub start_index: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub count: Option<i64>,
 }

--- a/src/models/others.rs
+++ b/src/models/others.rs
@@ -35,8 +35,9 @@ impl Default for SearchRequest {
 pub struct ListQuery {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter: Option<String>,
-    #[serde(rename = "startIndex")]
-    pub start_index: i64,
+    #[serde(rename = "startIndex", skip_serializing_if = "Option::is_none")]
+    pub start_index: Some(i64),
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub count: Option<i64>,
 }
 

--- a/src/models/others.rs
+++ b/src/models/others.rs
@@ -45,7 +45,7 @@ impl Default for ListQuery {
     fn default() -> Self {
         ListQuery {
             filter: Some("".to_string()),
-            start_index: 1,
+            start_index: Some(1),
             count: Some(100),
         }
     }

--- a/src/models/others.rs
+++ b/src/models/others.rs
@@ -33,7 +33,8 @@ impl Default for SearchRequest {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ListQuery {
-    pub filter: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<String>,
     #[serde(rename = "startIndex")]
     pub start_index: i64,
     pub count: Option<i64>,
@@ -42,7 +43,7 @@ pub struct ListQuery {
 impl Default for ListQuery {
     fn default() -> Self {
         ListQuery {
-            filter: "".to_string(),
+            filter: Some("".to_string()),
             start_index: 1,
             count: Some(100),
         }

--- a/src/models/others.rs
+++ b/src/models/others.rs
@@ -39,6 +39,10 @@ pub struct ListQuery {
     pub start_index: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub count: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attributes: Option<String>,
+    #[serde(rename = "excludedAttributes", skip_serializing_if = "Option::is_none")]
+    pub excluded_attributes: Option<String>,
 }
 
 impl Default for ListQuery {
@@ -47,6 +51,8 @@ impl Default for ListQuery {
             filter: Some("".to_string()),
             start_index: Some(1),
             count: Some(100),
+            attributes: Some("".to_string()),
+            excluded_attributes: Some("".to_string()),
         }
     }
 }

--- a/src/models/others.rs
+++ b/src/models/others.rs
@@ -114,22 +114,16 @@ impl Default for PatchOp {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PatchOperations {
     pub op: String,
-    pub value: PatchOpValue,
+    pub value: HashMap<String, Value>,
 }
 
 impl Default for PatchOperations {
     fn default() -> Self {
         PatchOperations {
             op: "".to_string(),
-            value: PatchOpValue::default(),
+            value: HashMap::new(),
         }
     }
-}
-
-#[derive(Default)]
-#[derive(Serialize, Deserialize, Debug)]
-pub struct PatchOpValue {
-    pub attributes: HashMap<String, Value>,
 }
 
 

--- a/src/models/others.rs
+++ b/src/models/others.rs
@@ -1,4 +1,7 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::models::group::Group;
 use crate::models::resource_types::ResourceType;
@@ -90,3 +93,44 @@ impl Default for ListResponse {
         }
     }
 }
+
+
+#[derive(Serialize, Deserialize, Debug)]
+struct PatchOp {
+    pub schemas: Vec<String>,
+    #[serde(rename = "Operations")]
+    pub operations: Vec<PatchOperations>,
+}
+
+impl Default for PatchOp {
+    fn default() -> Self {
+        PatchOp {
+            schemas: vec!["urn:ietf:params:scim:api:messages:2.0:PatchOp".to_string()],
+            operations: vec![PatchOperations::default()],
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct PatchOperations {
+    pub op: String,
+    pub value: PatchOpValue,
+}
+
+impl Default for PatchOperations {
+    fn default() -> Self {
+        PatchOperations {
+            op: "".to_string(),
+            value: PatchOpValue::default(),
+        }
+    }
+}
+
+#[derive(Default)]
+#[derive(Serialize, Deserialize, Debug)]
+struct PatchOpValue {
+    pub attributes: HashMap<String, Value>,
+}
+
+
+

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -3,6 +3,7 @@ use std::fmt::{Display, Formatter};
 
 #[derive(Debug)]
 pub enum SCIMError {
+    // Todo: Add 400 bad request SCIM Detail Error Keyword Values mentioned here: https://datatracker.ietf.org/doc/html/rfc7644#section-3.12
     ConflictError(String),
     DeserializationError(serde_json::Error),
     InvalidFieldValue(String),


### PR DESCRIPTION
When requesting a PATCH the format comes in as a patchOp.
ListQuery is not an offiical schema but a way to handle query parameters for filters and pagination as well as attributes.