### PR TITLE
Allow `ListResponse.Resources` to be omitted when `totalResults` is zero

### DIFF
--- a/src/models/others.rs
+++ b/src/models/others.rs
@@ -278,7 +278,9 @@ pub struct ListResponse<T> {
     pub total_results: i64,
     pub start_index: i64,
     pub schemas: Vec<String>,
-    #[serde(rename = "Resources")]
+    // RFC 7644 section 3.4.2: `Resources` is REQUIRED only if `totalResults` is
+    // non-zero, so a query returning no matches may omit it on the wire.
+    #[serde(rename = "Resources", default)]
     pub resources: Vec<Resource<T>>,
 }
 


### PR DESCRIPTION
## Summary

Adds `#[serde(default)]` to `ListResponse::resources` so that a `ListResponse` body without a `Resources` key deserializes to an empty list instead of failing.

## Motivation

[RFC 7644 §3.4.2](https://github.com/ShiftControl-io/scim-v2-rust/blob/0e31134aedd86c2aed56cbf9e1558d027575cfe3/docs/rfcs/rfc7644.txt#L827-L830) makes `Resources` conditionally required:

> **Resources** A multi-valued list of complex objects containing the requested resources. This MAY be a subset of the full set of resources if pagination (Section 3.4.2.4) is requested. **REQUIRED if "totalResults" is non-zero.**


Thanks for the crate, it saved us building the SCIM model layer from scratch.