### PR TITLE
Handle missing `primary` field when deserializing `Role`

### DIFF
--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -212,6 +212,7 @@ pub struct Role {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<String>,
     #[serde(
+        default, // required as `deserialize_with` does not set default when field is missing
         skip_serializing_if = "Option::is_none",
         deserialize_with = "deserialize_optional_lenient_bool"
     )]
@@ -350,6 +351,27 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    /// Minimal reproduction: the bug is isolated entirely to `Role`
+    /// deserialization, independent of the surrounding `User`/`ListResponse`
+    /// shape. GitHub Enterprise omits `primary` on `Role` objects rather
+    /// than sending a JSON boolean (e.g. `{"value": "enterprise_owner"}`
+    /// with no `primary` key at all), and `Role::primary`'s
+    /// `deserialize_with` attribute — without an accompanying
+    /// `#[serde(default)]` — turns an absent key into a hard `missing
+    /// field` error instead of defaulting to `None`.
+    #[test]
+    fn role_deserialization_with_omitted_primary_key() {
+        let payload = r#"{ "value": "custom_role" }"#;
+
+        let result = serde_json::from_str::<Role>(payload);
+
+        assert!(
+            result.is_ok(),
+            "failed to deserialize Role with missing `primary` field: {:?}",
+            result.err()
+        );
+    }
 
     #[test]
     fn user_deserialization_with_minimum_fields() {

--- a/src/utils/serde.rs
+++ b/src/utils/serde.rs
@@ -1,5 +1,8 @@
 use serde::Deserializer;
 
+/// Deserializes to a boolean from either a boolean, string representation of boolean, or null.
+///
+/// Note: Must be paired with `#[serde(default)]` in order to handle missing fields.
 pub(crate) fn deserialize_optional_lenient_bool<'de, D>(
     deserializer: D,
 ) -> Result<Option<bool>, D::Error>
@@ -41,4 +44,69 @@ where
     }
 
     deserializer.deserialize_any(OptionalLenientBoolVisitor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    struct WithDefault {
+        #[serde(default, deserialize_with = "deserialize_optional_lenient_bool")]
+        primary: Option<bool>,
+    }
+
+    #[derive(Deserialize)]
+    struct WithoutDefault {
+        #[serde(deserialize_with = "deserialize_optional_lenient_bool")]
+        #[allow(dead_code)]
+        primary: Option<bool>,
+    }
+
+    #[test]
+    fn accepts_a_real_bool() {
+        let parsed: WithDefault = serde_json::from_str(r#"{"primary": true}"#).unwrap();
+        assert_eq!(parsed.primary, Some(true));
+
+        let parsed: WithDefault = serde_json::from_str(r#"{"primary": false}"#).unwrap();
+        assert_eq!(parsed.primary, Some(false));
+    }
+
+    #[test]
+    fn accepts_a_stringified_bool_case_insensitively() {
+        let parsed: WithDefault = serde_json::from_str(r#"{"primary": "True"}"#).unwrap();
+        assert_eq!(parsed.primary, Some(true));
+
+        let parsed: WithDefault = serde_json::from_str(r#"{"primary": "false"}"#).unwrap();
+        assert_eq!(parsed.primary, Some(false));
+    }
+
+    #[test]
+    fn rejects_a_non_boolean_string() {
+        let result: Result<WithDefault, _> = serde_json::from_str(r#"{"primary": "maybe"}"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn explicit_null_deserializes_to_none() {
+        let parsed: WithDefault = serde_json::from_str(r#"{"primary": null}"#).unwrap();
+        assert_eq!(parsed.primary, None);
+    }
+
+    #[test]
+    fn omitted_key_deserializes_to_none_when_paired_with_serde_default() {
+        let parsed: WithDefault = serde_json::from_str(r#"{}"#).unwrap();
+        assert_eq!(parsed.primary, None);
+    }
+
+    #[test]
+    fn omitted_key_fails_without_serde_default() {
+        let result: Result<WithoutDefault, _> = serde_json::from_str(r#"{}"#);
+        assert!(
+            result.is_err(),
+            "deserialize_with alone does not default an omitted key to None; \
+             #[serde(default)] is required at the call site"
+        );
+    }
 }


### PR DESCRIPTION
Fixes regression introduced as part of `0.4.x` releases.

When using `#[serde(deserialize_with = deserialize_optional_lenient_bool)`, this disables `serde`'s graceful handling of omitted `Option<T>` fields, which would normally just deserialize to `Option::None`.

Because the `primary` field on `Role` was missing `#[serde(default)]` it meant that a serialized representation missing that optional field would be treated as invalid.

Added some tests and docs to reinforce the rationale for the change. 