### PR TITLE
fix(models): handle missing `primary` field when deserializing `Role` (signed re-push of #44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.4.2
+
+### Fixed
+- `Role.primary` may again be omitted on the wire and deserializes to `None`. The lenient bool deserializer added in 0.4 suppressed serde's implicit `Option` default, so a `Role` without a `primary` key (as sent by GitHub Enterprise, e.g. `{"value": "enterprise_owner"}`) failed with a `missing field` error. Pairing `deserialize_with` with `#[serde(default)]` restores the 0.3 behaviour while keeping the stringified-bool leniency Entra requires.
+
 ## 0.4.1
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scim_v2"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 authors = ["Dan Gericke <dan@shiftcontrol.io>"]
 description = "A crate that provides utilities for working with the System for Cross-domain Identity Management (SCIM) version 2.0 protocol. (rfc7642, rfc7643, rfc7644)"

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -212,6 +212,7 @@ pub struct Role {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<String>,
     #[serde(
+        default, // required as `deserialize_with` does not set default when field is missing
         skip_serializing_if = "Option::is_none",
         deserialize_with = "deserialize_optional_lenient_bool"
     )]
@@ -350,6 +351,27 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    /// Minimal reproduction: the bug is isolated entirely to `Role`
+    /// deserialization, independent of the surrounding `User`/`ListResponse`
+    /// shape. GitHub Enterprise omits `primary` on `Role` objects rather
+    /// than sending a JSON boolean (e.g. `{"value": "enterprise_owner"}`
+    /// with no `primary` key at all), and `Role::primary`'s
+    /// `deserialize_with` attribute — without an accompanying
+    /// `#[serde(default)]` — turns an absent key into a hard `missing
+    /// field` error instead of defaulting to `None`.
+    #[test]
+    fn role_deserialization_with_omitted_primary_key() {
+        let payload = r#"{ "value": "custom_role" }"#;
+
+        let result = serde_json::from_str::<Role>(payload);
+
+        assert!(
+            result.is_ok(),
+            "failed to deserialize Role with missing `primary` field: {:?}",
+            result.err()
+        );
+    }
 
     #[test]
     fn user_deserialization_with_minimum_fields() {
@@ -772,5 +794,25 @@ mod tests {
         let user: Result<User, serde_json::Error> =
             serde_json::from_str(include_str!("../test_data/entra_user_creation_test.json"));
         user.expect("user should deserialize");
+    }
+
+    /// End-to-end regression for the omitted `Role.primary` key, using a
+    /// sanitized real response from GitHub Enterprise's SCIM `/Users`
+    /// endpoint. The first resource carries a role with `primary` absent
+    /// (`{"value": "enterprise_owner"}`); the second carries an empty
+    /// `roles` array. Before the `#[serde(default)]` fix, the first
+    /// resource failed with a `missing field \`primary\`` error, taking the
+    /// whole `ListResponse` down with it.
+    #[test]
+    fn deserialize_github_enterprise_user_list() {
+        use crate::models::others::ListResponse;
+
+        let list: ListResponse<String> = serde_json::from_str(include_str!(
+            "../test_data/github_enterprise_user_list_test.json"
+        ))
+        .expect("GitHub Enterprise user list should deserialize");
+
+        assert_eq!(list.total_results, 2);
+        assert_eq!(list.resources.len(), 2);
     }
 }

--- a/src/test_data/github_enterprise_user_list_test.json
+++ b/src/test_data/github_enterprise_user_list_test.json
@@ -1,0 +1,118 @@
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+  "totalResults": 2,
+  "itemsPerPage": 2,
+  "startIndex": 1,
+  "Resources": [
+    {
+      "emails": [
+        {
+          "value": "john.smith@website.com",
+          "type": "work",
+          "primary": true
+        }
+      ],
+      "roles": [
+        {
+          "value": "enterprise_owner"
+        }
+      ],
+      "active": true,
+      "displayName": "john smith",
+      "externalId": "deadbeef-3618-4976-bcbb-deadbeef1234",
+      "name": {
+        "familyName": "smith",
+        "givenName": "john"
+      },
+      "userName": "john.smith@website.com",
+      "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+      "id": "deadbeef-f0ae-11f0-8592-deadbeef1234",
+      "meta": {
+        "resourceType": "User",
+        "created": "2026-01-13T10:33:16.000-08:00",
+        "lastModified": "2026-01-13T10:43:27.000-08:00",
+        "location": "https://my.scim.server.com/scim/v2/enterprises/my-enterprise/Users/deadbeef-f0ae-11f0-8592-deadbeef1234"
+      },
+      "groups": [
+        {
+          "value": "deadbeef-f0ae-11f0-9133-deadbeef1234",
+          "$ref": "https://my.scim.server.com/scim/v2/enterprises/my-enterprise/Groups/deadbeef-f0ae-11f0-9133-deadbeef1234",
+          "display": "Group 1"
+        },
+        {
+          "value": "deadbeef-f0b3-11f0-9e21-deadbeef1234",
+          "$ref": "https://my.scim.server.com/scim/v2/enterprises/my-enterprise/Groups/deadbeef-f0b3-11f0-9e21-deadbeef1234",
+          "display": "Group 2"
+        },
+        {
+          "value": "deadbeef-4fdb-11f1-8fb3-deadbeef1234",
+          "$ref": "https://my.scim.server.com/scim/v2/enterprises/my-enterprise/Groups/deadbeef-4fdb-11f1-8fb3-deadbeef1234",
+          "display": "Group 3"
+        },
+        {
+          "value": "deadbeef-6460-11f1-94d6-deadbeef1234",
+          "$ref": "https://my.scim.server.com/scim/v2/enterprises/my-enterprise/Groups/deadbeef-6460-11f1-94d6-deadbeef1234",
+          "display": "Group 4"
+        },
+        {
+          "value": "deadbeef-6464-11f1-9979-deadbeef1234",
+          "$ref": "https://my.scim.server.com/scim/v2/enterprises/my-enterprise/Groups/deadbeef-6464-11f1-9979-deadbeef1234",
+          "display": "Group 5"
+        },
+        {
+          "value": "deadbeef-6464-11f1-9543-deadbeef1234",
+          "$ref": "https://my.scim.server.com/scim/v2/enterprises/my-enterprise/Groups/deadbeef-6464-11f1-9543-deadbeef1234",
+          "display": "Group 6"
+        },
+        {
+          "value": "deadbeef-6464-11f1-885f-deadbeef1234",
+          "$ref": "https://my.scim.server.com/scim/v2/enterprises/my-enterprise/Groups/deadbeef-6464-11f1-885f-deadbeef1234",
+          "display": "Group 7"
+        },
+        {
+          "value": "deadbeef-6464-11f1-9db2-deadbeef1234",
+          "$ref": "https://my.scim.server.com/scim/v2/enterprises/my-enterprise/Groups/deadbeef-6464-11f1-9db2-deadbeef1234",
+          "display": "Group 8"
+        },
+        {
+          "value": "deadbeef-6464-11f1-8917-deadbeef1234",
+          "$ref": "https://my.scim.server.com/scim/v2/enterprises/my-enterprise/Groups/deadbeef-6464-11f1-8917-deadbeef1234",
+          "display": "Group 9"
+        }
+      ]
+    },
+    {
+      "emails": [
+        {
+          "value": "ace.ventura@website.com",
+          "type": "work",
+          "primary": true
+        }
+      ],
+      "roles": [],
+      "active": true,
+      "displayName": "ace ventura",
+      "externalId": "deadbeef-b7ec-4645-a3a7-deadbeef1234",
+      "name": {
+        "familyName": "ventura",
+        "givenName": "ace"
+      },
+      "userName": "ace.ventura@website.com",
+      "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+      "id": "deadbeef-3da3-11f1-923d-deadbeef1234",
+      "meta": {
+        "resourceType": "User",
+        "created": "2026-04-21T09:56:44.000-07:00",
+        "lastModified": "2026-04-21T09:56:44.000-07:00",
+        "location": "https://my.scim.server.com/scim/v2/enterprises/my-enterprise/Users/deadbeef-3da3-11f1-923d-deadbeef1234"
+      },
+      "groups": [
+        {
+          "value": "deadbeef-f0b3-11f0-9e21-deadbeef1234",
+          "$ref": "https://my.scim.server.com/scim/v2/enterprises/my-enterprise/Groups/deadbeef-f0b3-11f0-9e21-deadbeef1234",
+          "display": "Group 2"
+        }
+      ]
+    }
+  ]
+}

--- a/src/utils/serde.rs
+++ b/src/utils/serde.rs
@@ -1,5 +1,8 @@
 use serde::Deserializer;
 
+/// Deserializes to a boolean from either a boolean, string representation of boolean, or null.
+///
+/// Note: Must be paired with `#[serde(default)]` in order to handle missing fields.
 pub(crate) fn deserialize_optional_lenient_bool<'de, D>(
     deserializer: D,
 ) -> Result<Option<bool>, D::Error>
@@ -41,4 +44,69 @@ where
     }
 
     deserializer.deserialize_any(OptionalLenientBoolVisitor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    struct WithDefault {
+        #[serde(default, deserialize_with = "deserialize_optional_lenient_bool")]
+        primary: Option<bool>,
+    }
+
+    #[derive(Deserialize)]
+    struct WithoutDefault {
+        #[serde(deserialize_with = "deserialize_optional_lenient_bool")]
+        #[allow(dead_code)]
+        primary: Option<bool>,
+    }
+
+    #[test]
+    fn accepts_a_real_bool() {
+        let parsed: WithDefault = serde_json::from_str(r#"{"primary": true}"#).unwrap();
+        assert_eq!(parsed.primary, Some(true));
+
+        let parsed: WithDefault = serde_json::from_str(r#"{"primary": false}"#).unwrap();
+        assert_eq!(parsed.primary, Some(false));
+    }
+
+    #[test]
+    fn accepts_a_stringified_bool_case_insensitively() {
+        let parsed: WithDefault = serde_json::from_str(r#"{"primary": "True"}"#).unwrap();
+        assert_eq!(parsed.primary, Some(true));
+
+        let parsed: WithDefault = serde_json::from_str(r#"{"primary": "false"}"#).unwrap();
+        assert_eq!(parsed.primary, Some(false));
+    }
+
+    #[test]
+    fn rejects_a_non_boolean_string() {
+        let result: Result<WithDefault, _> = serde_json::from_str(r#"{"primary": "maybe"}"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn explicit_null_deserializes_to_none() {
+        let parsed: WithDefault = serde_json::from_str(r#"{"primary": null}"#).unwrap();
+        assert_eq!(parsed.primary, None);
+    }
+
+    #[test]
+    fn omitted_key_deserializes_to_none_when_paired_with_serde_default() {
+        let parsed: WithDefault = serde_json::from_str(r#"{}"#).unwrap();
+        assert_eq!(parsed.primary, None);
+    }
+
+    #[test]
+    fn omitted_key_fails_without_serde_default() {
+        let result: Result<WithoutDefault, _> = serde_json::from_str(r#"{}"#);
+        assert!(
+            result.is_err(),
+            "deserialize_with alone does not default an omitted key to None; \
+             #[serde(default)] is required at the call site"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Signed re-push of @travipross' commit from #44 (that commit carried an S/MIME signature from an internal CA that GitHub reports as `no_user`, so it could not satisfy the signed-commits rule on `main`), plus an end-to-end regression test, a version bump, and changelog notes.

`Role::primary` gains `#[serde(default)]`. Applying `deserialize_with` suppresses serde's implicit handling of omitted `Option<T>` fields, so without an accompanying `default` a payload that simply omits `primary` was rejected with a `missing field` error rather than deserializing to `None`. This regressed 0.3 behaviour during the 0.4.x lenient-bool work.

```rust
#[serde(
    default, // required as `deserialize_with` does not set default when field is missing
    skip_serializing_if = "Option::is_none",
    deserialize_with = "deserialize_optional_lenient_bool"
)]
pub primary: Option<bool>,
```

## Tests

Carried over from #44:
- `role_deserialization_with_omitted_primary_key` — minimal reproduction isolating the bug to `Role`.
- Six unit tests on `deserialize_optional_lenient_bool` in `src/utils/serde.rs`, including `omitted_key_fails_without_serde_default`, which pins the reason `default` is required at the call site.

Added here:
- `deserialize_github_enterprise_user_list`, driven by a new `src/test_data/github_enterprise_user_list_test.json` fixture. This is the sanitized real GitHub Enterprise SCIM `/Users` response @travipross supplied in [this comment](https://github.com/ShiftControl-io/scim-v2-rust/pull/44#issuecomment-5300278272). The first resource carries a role with `primary` absent (`{"value": "enterprise_owner"}`), the second an empty `roles` array. It exercises the failure at the `ListResponse` level, which is where it actually bit.

Both regression tests were confirmed to fail against the unfixed code, with the reported error:

```
role_deserialization_with_omitted_primary_key ... FAILED
  missing field `primary`, line: 1, column: 26
deserialize_github_enterprise_user_list ... FAILED
  missing field `primary`, line: 84, column: 4
```

## Scope note

Devin flagged that the other multi-valued structs (`Email`, `PhoneNumber`, `Im`, `Photo`, `Entitlement`, `X509Certificate`) keep a plain `Option<bool>` and would still reject a stringified `"true"`. Left as-is deliberately, for two reasons:

- The missing-field bug only occurs where `deserialize_with` is present, since that is what suppresses serde's `Option` default. `Role::primary` is the only production use of `deserialize_with` in the crate, so there are no other latent instances. Plain `Option<bool>` fields already default to `None` when the key is absent.
- The leniency itself is targeted, not general. It arrived in `8d5cc19` alongside `src/test_data/entra_user_creation_test.json` (from Microsoft's SCIM validator), where Entra sends a real boolean for `primary` on `emails` and `phoneNumbers` and a string only on `roles`. Widening it elsewhere has no driving case today.

## Release

- `Cargo.toml` 0.4.1 → 0.4.2 (`Cargo.lock` is gitignored, matching #42).
- `CHANGELOG.md` gains a 0.4.2 `Fixed` entry.

Tagging `v0.4.2` after merge triggers publish + release.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (137 unit + 37 doctests) all pass locally.

Original authorship is credited via `Co-authored-by`. #44 can be closed once this merges.
