### PR TITLE
Consistently skip serializing `Option<T>` fields when `None`

### DIFF
--- a/src/models/enterprise_user.rs
+++ b/src/models/enterprise_user.rs
@@ -165,11 +165,93 @@ impl EnterpriseUser {
     }
 }
 
+/// The user's manager.
+///
+/// Unassigned fields are omitted from serialized output rather than emitted as
+/// `null`; RFC 7643 §2.5 treats the two as equivalent in resource state. Note
+/// the consequence for `PUT`: per RFC 7644 §3.5.1 an omitted `readWrite`
+/// attribute (`value`, `$ref`) is "not asserted by the client" and the server
+/// MAY keep the existing value or apply a default — it is *not* a deterministic
+/// clear. Callers that need to clear a field on `PUT` should use a `PATCH`
+/// operation or hand-build a `serde_json::Value` carrying an explicit `null`.
+/// (`displayName` is `readOnly`, so §3.5.1 says the server SHALL ignore it.)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Manager {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
-    #[serde(rename = "$ref")]
+    #[serde(rename = "$ref", skip_serializing_if = "Option::is_none")]
     pub r#ref: Option<String>,
-    #[serde(rename = "displayName")]
+    #[serde(rename = "displayName", skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Unset `Manager` fields are omitted on serialize, not emitted as
+    /// `null` (RFC 7643 §2.5 treats the two as equivalent, but omission
+    /// keeps output compact and matches every other model in the crate).
+    #[test]
+    fn manager_omits_unset_fields_on_serialize() {
+        let manager = Manager {
+            value: Some("26118915-6090-4610-87e4-49d8ca9f808d".to_string()),
+            r#ref: None,
+            display_name: None,
+        };
+        let serialized = serde_json::to_value(&manager).unwrap();
+        assert_eq!(
+            serialized,
+            json!({ "value": "26118915-6090-4610-87e4-49d8ca9f808d" })
+        );
+    }
+
+    /// A fully-unset `Manager` serializes to an empty object rather than
+    /// one populated with `null`s. This pins the `value` field too, which
+    /// `manager_omits_unset_fields_on_serialize` leaves set.
+    #[test]
+    fn manager_omits_all_unset_fields_on_serialize() {
+        let manager = Manager {
+            value: None,
+            r#ref: None,
+            display_name: None,
+        };
+        assert_eq!(serde_json::to_value(&manager).unwrap(), json!({}));
+    }
+
+    /// The read path must keep accepting explicit `null` sub-attributes from
+    /// peers that send them (RFC 7643 §2.5) — a missing key, `null`, and `{}`
+    /// all deserialize to `None`. Regression guard against a future
+    /// `#[serde(default)]`, `deny_unknown_fields`, or custom deserializer
+    /// silently changing this (cf. `Role.primary`, CHANGELOG 0.4.2).
+    #[test]
+    fn manager_explicit_null_deserializes_to_none() {
+        let manager: Manager = serde_json::from_str(
+            r#"{"value": "26118915-6090-4610-87e4-49d8ca9f808d", "$ref": null, "displayName": null}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            manager.value.as_deref(),
+            Some("26118915-6090-4610-87e4-49d8ca9f808d")
+        );
+        assert_eq!(manager.r#ref, None);
+        assert_eq!(manager.display_name, None);
+
+        let empty: Manager = serde_json::from_str("{}").unwrap();
+        assert_eq!(empty.value, None);
+        assert_eq!(empty.r#ref, None);
+        assert_eq!(empty.display_name, None);
+    }
+
+    #[test]
+    fn manager_round_trips_all_fields() {
+        let raw = json!({
+            "value": "26118915-6090-4610-87e4-49d8ca9f808d",
+            "$ref": "https://example.com/v2/Users/26118915-6090-4610-87e4-49d8ca9f808d",
+            "displayName": "John Smith"
+        });
+        let manager: Manager = serde_json::from_value(raw.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&manager).unwrap(), raw);
+    }
 }

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -96,9 +96,20 @@ impl<T> Default for User<T> {
     }
 }
 
+/// The components of the user's name.
+///
+/// Unassigned sub-attributes are omitted from serialized output rather than
+/// emitted as `null`; RFC 7643 §2.5 treats the two as equivalent in resource
+/// state. Note the consequence for `PUT`: per RFC 7644 §3.5.1 an omitted
+/// `readWrite` attribute is "not asserted by the client" and the server MAY
+/// keep the existing value or apply a default — it is *not* a deterministic
+/// clear. Callers that need to clear a sub-attribute on `PUT` should use a
+/// `PATCH` operation or hand-build a `serde_json::Value` carrying an explicit
+/// `null`.
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Name {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub formatted: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub family_name: Option<String>,
@@ -917,6 +928,65 @@ mod tests {
             assert_eq!(
                 user.meta.as_ref().unwrap().last_modified.as_deref(),
                 Some("2011-08-08T08:00:12Z")
+            );
+        }
+        /// An unset `Name.formatted` is omitted on serialize rather than
+        /// emitted as `null` — consistent with the rest of `Name` and every
+        /// other model in the crate. RFC 7643 §2.5 treats `null` and omitted
+        /// as equivalent, so this is a compactness/consistency choice, and a
+        /// present value still round-trips.
+        #[test]
+        fn name_omits_unset_formatted_on_serialize() {
+            let name = Name {
+                formatted: None,
+                family_name: Some("Jensen".to_string()),
+                given_name: Some("Barbara".to_string()),
+                ..Name::default()
+            };
+            let serialized = serde_json::to_string(&name).unwrap();
+            assert!(
+                !serialized.contains("formatted"),
+                "unset formatted must not appear on the wire: {serialized}"
+            );
+            assert!(
+                !serialized.contains("null"),
+                "no field should be null: {serialized}"
+            );
+
+            let full = Name {
+                formatted: Some("Ms. Barbara J Jensen III".to_string()),
+                ..name
+            };
+            let round: Name = serde_json::from_str(&serde_json::to_string(&full).unwrap()).unwrap();
+            assert_eq!(round.formatted.as_deref(), Some("Ms. Barbara J Jensen III"));
+            assert_eq!(round.family_name.as_deref(), Some("Jensen"));
+        }
+
+        /// The read path must keep accepting an explicit `"formatted": null` from
+        /// peers that send it (RFC 7643 §2.5) — a missing key, `null`, and `{}`
+        /// all deserialize to `None`. Regression guard against a future
+        /// `#[serde(default)]`, `deny_unknown_fields`, or custom deserializer
+        /// silently changing this (cf. `Role.primary`, CHANGELOG 0.4.2).
+        #[test]
+        fn name_explicit_null_deserializes_to_none() {
+            let name: Name =
+                serde_json::from_str(r#"{"formatted": null, "familyName": "Jensen"}"#).unwrap();
+            assert_eq!(name.formatted, None);
+            assert_eq!(name.family_name.as_deref(), Some("Jensen"));
+
+            let empty: Name = serde_json::from_str("{}").unwrap();
+            assert_eq!(empty.formatted, None);
+        }
+
+        /// A fully-unset `Name` serializes to an empty object, not one padded
+        /// with `null`s. `formatted` was the last field without
+        /// `skip_serializing_if`, so before this it emitted `{"formatted":null}`.
+        /// Nested in a `User` this is the `"name":{}` a downstream peer receives.
+        #[test]
+        fn name_default_serializes_to_empty_object() {
+            assert_eq!(
+                serde_json::to_value(Name::default()).unwrap(),
+                serde_json::json!({})
             );
         }
     }


### PR DESCRIPTION
## Summary

[RFC 7643 states](https://datatracker.ietf.org/doc/html/rfc7643#section-2.5):

> Unassigned attributes, the null value, or an empty array (in the case of a multi-valued attribute) SHALL be considered to be equivalent in "state".  Assigning an attribute with the value "null" or an empty array (in the case of multi-valued attributes) has the effect of making the attribute "unassigned".  **When a resource is expressed in JSON format, unassigned attributes, although they are defined in schema, MAY be omitted for compactness**.

As this crate already established a widely-followed precedent for skipping serialization when some `Option<T>` fields were `None`, this PR updates a few outliers for conformance with this established convention.

## Additional Notes

There was no established precedent of annotating `Vec<T>` fields with `#[serde(skip_serializing_if = "Vec::is_empty")]`, and so these cases were ignored. However, it's worth noting that many fields are (arguably redundantly) defined as `Option<Vec<T>>` and annotated with `#[serde(skip_serializing_if = "Option::is_none")]`, which remains an inconsistency within the crate. 

As a suggestion for future work (or perhaps as an revision to this change), I'd suggest that these fields be eventually modelled as `Vec<T>`, and allow `serde` to appropriately handle the deserialization logic given the explicit, RFC-stated equivalence between `Option<Vec<T>>::None` and an empty `Vec<T>`.