### PR TITLE
chore(release): 0.5.0 — RFC 7644 conformance from #47 and #48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # CHANGELOG
 
+## 0.5.0
+
+Releases the RFC 7644 conformance work from #47 and #48. A minor bump rather
+than a patch, because two field types changed and `^0.4` treats that as
+breaking.
+
+### Breaking Changes
+
+- `ListResponse.items_per_page` and `ListResponse.start_index` are now
+  `Option<i64>`, and so are `SearchRequest.start_index` and
+  `SearchRequest.count`. RFC 7644 §3.4.2 makes the two `ListResponse`
+  pagination markers REQUIRED only "when partial results are returned due to
+  pagination", and §3.4.3 marks both `SearchRequest` fields OPTIONAL — so the
+  crate could not deserialize the RFC's own unpaginated `ListResponse`
+  example, nor an RFC-legal `SearchRequest` that omitted them. `Option<i64>`
+  rather than `#[serde(default)]` to an inert `0`, so a server that really
+  sent `0` stays distinguishable from one that omitted the field. Migration is
+  mechanical: wrap reads in `Option`, or `.unwrap_or(1)` / `.unwrap_or(0)` at
+  the call site.
+
+### Added
+
+- `ListResponse::validate()`, matching the per-model convention. Checks that
+  `schemas` is present, and that a partial page — fewer entries in `Resources`
+  than `totalResults` — carries both pagination markers, which §3.4.2 requires
+  in exactly that case. The `skip_serializing_if` on those fields otherwise
+  makes a non-conformant response expressible.
+- A corpus of 22 RFC 7644 sample payloads and 5 sanitized provider responses
+  under `src/test_data/`, each documented with its RFC section in
+  `src/test_data/README.md`, plus round-trip tests over them.
+
+### Fixed
+
+- Unassigned `Option` fields are consistently omitted on serialize rather than
+  emitted as `null`: `Name.formatted`, and four fields on `EnterpriseUser`.
+  RFC 7643 §2.5 treats `null` and omitted as equivalent in state and permits
+  the compact form, and the rest of the crate already did this. A fully-unset
+  `Name` now serializes to `{}` rather than `{"formatted":null}`. Thanks to
+  @travipross for both #47 and #48.
+
 ## 0.4.2
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scim_v2"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 authors = ["Dan Gericke <dan@shiftcontrol.io>"]
 description = "A crate that provides utilities for working with the System for Cross-domain Identity Management (SCIM) version 2.0 protocol. (rfc7642, rfc7643, rfc7644)"


### PR DESCRIPTION
## Summary

Cuts **0.5.0**, releasing the RFC 7644 conformance work from #47 and #48 so it is installable from crates.io without waiting on the 1.0 work in #49. @travipross contributed both and asked to be able to use it.

Version bump and CHANGELOG only — no code changes. Everything being released is already on `main`.

## Type of change

- [ ] Bug fix (no API change)
- [ ] New feature (no API change)
- [x] Breaking change (requires a major version bump)
- [ ] Test coverage only
- [x] Documentation only
- [ ] Tooling / CI / repo config

## Why a minor bump and not a patch

`ListResponse.items_per_page`, `ListResponse.start_index`, `SearchRequest.start_index` and `SearchRequest.count` went from `i64` to `Option<i64>` in #47. That breaks every consumer reading them as plain integers, and under `^0.4` the minor is the breaking axis.

Confirmed rather than assumed. An ordinary consumer function:

```rust
use scim_v2::models::others::ListResponse;

pub fn page_size(list: &ListResponse<String>) -> i64 {
    list.items_per_page + list.start_index
}
```

compiles against `0.4.2` and fails against this tree with `error[E0369]: cannot add Option<i64> to Option<i64>`.

Worth recording that `cargo-semver-checks` passes a `0.4.3` patch bump on this same diff — it has no lint for a public field's type changing. Useful to know before leaning on the SemVer job that #49 adds: it is a backstop for the cases it covers, not a substitute for reading the diff.

## What 0.5.0 contains

**Breaking** — the four pagination fields above become `Option<i64>`. RFC 7644 §3.4.2 makes the two `ListResponse` markers REQUIRED only "when partial results are returned due to pagination", and §3.4.3 marks both `SearchRequest` fields OPTIONAL, so the crate could not deserialize the RFC's own unpaginated `ListResponse` example nor an RFC-legal `SearchRequest` omitting them. `Option<i64>` rather than `#[serde(default)]` to an inert `0`, so a server that really sent `0` stays distinguishable from one that omitted the field. Migration is mechanical: `.unwrap_or(1)` / `.unwrap_or(0)` at the call site.

**Added** — `ListResponse::validate()`, matching the per-model convention: `schemas` present, and a partial page (fewer entries in `Resources` than `totalResults`) carrying both pagination markers, which §3.4.2 requires in exactly that case. Plus a corpus of 22 RFC 7644 sample payloads and 5 sanitized provider responses under `src/test_data/`, each documented with its RFC section.

**Fixed** — unassigned `Option` fields are consistently omitted on serialize rather than emitted as `null`: `Name.formatted` and four on `EnterpriseUser`. RFC 7643 §2.5 treats `null` and omitted as equivalent in state and permits the compact form, and the rest of the crate already did this. A fully-unset `Name` now serializes to `{}` rather than `{"formatted":null}`.

## Test plan

- `cargo test`: 171 unit + 38 doctests, all green
- `cargo clippy -- -D warnings` clean, `cargo fmt --check` clean
- `cargo semver-checks` reports no further bump required for `0.4.2 -> 0.5.0`
- Break verified directly against the published `0.4.2`, as above

## Ordering

Merge this first, then #49 (1.0.0) rebases on top. #49 is currently stacked on this branch so its diff shows only the 1.0 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUsHHmCDA7RNyTLAER2fVW
